### PR TITLE
Evan/algos become microalgos

### DIFF
--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -35,7 +35,7 @@ func MakePaymentTxn(from, to string, fee, amount, firstRound, lastRound uint64, 
 		Type: types.PaymentTx,
 		Header: types.Header{
 			Sender:     fromAddr,
-			Fee:        types.Algos(fee),
+			Fee:        types.MicroAlgos(fee),
 			FirstValid: types.Round(firstRound),
 			LastValid:  types.Round(lastRound),
 			Note:       note,
@@ -43,7 +43,7 @@ func MakePaymentTxn(from, to string, fee, amount, firstRound, lastRound uint64, 
 		},
 		PaymentTxnFields: types.PaymentTxnFields{
 			Receiver:         toAddr,
-			Amount:           types.Algos(amount),
+			Amount:           types.MicroAlgos(amount),
 			CloseRemainderTo: closeRemainderToAddr,
 		},
 	}
@@ -53,7 +53,7 @@ func MakePaymentTxn(from, to string, fee, amount, firstRound, lastRound uint64, 
 	if err != nil {
 		return types.Transaction{}, err
 	}
-	tx.Fee = types.Algos(eSize * fee)
+	tx.Fee = types.MicroAlgos(eSize * fee)
 
 	return tx, nil
 }

--- a/types/basics.go
+++ b/types/basics.go
@@ -28,10 +28,12 @@ type MasterDerivationKey [32]byte
 // Digest is a SHA512_256 hash
 type Digest [hashLenBytes]byte
 
-func ToAlgos(microalgos MicroAlgos) uint64 {
-	return uint64(microalgos) / 1e6
+const microAlgoConversionFactor = 1e6
+
+func (microalgos MicroAlgos) ToAlgos() uint64 {
+	return uint64(microalgos) / microAlgoConversionFactor
 }
 
 func ToMicroAlgos(algos uint64) MicroAlgos {
-	return MicroAlgos(algos * 1e6)
+	return MicroAlgos(algos * microAlgoConversionFactor)
 }

--- a/types/basics.go
+++ b/types/basics.go
@@ -10,7 +10,7 @@ const (
 	KeyRegistrationTx TxType = "keyreg"
 )
 
-// MicroAlgos are the unit of currency in Algorand
+// MicroAlgos are the base unit of currency in Algorand
 type MicroAlgos uint64
 
 // Round represents a round of the Algorand consensus protocol
@@ -27,3 +27,11 @@ type MasterDerivationKey [32]byte
 
 // Digest is a SHA512_256 hash
 type Digest [hashLenBytes]byte
+
+func ToAlgos(microalgos MicroAlgos) uint64 {
+	return uint64(microalgos) / 1e6
+}
+
+func ToMicroAlgos(algos uint64) MicroAlgos {
+	return MicroAlgos(algos * 1e6)
+}

--- a/types/basics.go
+++ b/types/basics.go
@@ -10,8 +10,8 @@ const (
 	KeyRegistrationTx TxType = "keyreg"
 )
 
-// Algos are the unit of currency in Algorand
-type Algos uint64
+// MicroAlgos are the unit of currency in Algorand
+type MicroAlgos uint64
 
 // Round represents a round of the Algorand consensus protocol
 type Round uint64

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -37,8 +37,8 @@ type KeyregTxnFields struct {
 type PaymentTxnFields struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	Receiver Address `codec:"rcv"`
-	Amount   Algos   `codec:"amt"`
+	Receiver Address    `codec:"rcv"`
+	Amount   MicroAlgos `codec:"amt"`
 
 	// When CloseRemainderTo is set, it indicates that the
 	// transaction is requesting that the account should be
@@ -51,10 +51,10 @@ type PaymentTxnFields struct {
 type Header struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	Sender     Address `codec:"snd"`
-	Fee        Algos   `codec:"fee"`
-	FirstValid Round   `codec:"fv"`
-	LastValid  Round   `codec:"lv"`
-	Note       []byte  `codec:"note"`
-	GenesisID  string  `codec:"gen"`
+	Sender     Address    `codec:"snd"`
+	Fee        MicroAlgos `codec:"fee"`
+	FirstValid Round      `codec:"fv"`
+	LastValid  Round      `codec:"lv"`
+	Note       []byte     `codec:"note"`
+	GenesisID  string     `codec:"gen"`
 }


### PR DESCRIPTION
## Summary
This PR proposes to change references to `Algos` to references to `MicroAlgos`. It also adds a ToAlgos and ToMicroAlgos to the `types` subpackage.