### PR TITLE
Add support for pending transactions /transactions/pending/<txid>

### DIFF
--- a/client/algod/models/models.go
+++ b/client/algod/models/models.go
@@ -228,6 +228,12 @@ type Transaction struct {
 	// ConfirmedRound indicates the block number this transaction appeared in
 	ConfirmedRound uint64 `json:"round,omitempty"`
 
+	// PoolError indicates the transaction was evicted from this node's transaction
+	// pool (if non-empty).  A non-empty PoolError does not guarantee that the
+	// transaction will never be committed; other nodes may not have evicted the
+	// transaction and may attempt to commit it in the future.
+	PoolError string `json:"poolerror,omitempty"`
+
 	// Fee is the transaction fee
 	// Required: true
 	Fee uint64 `json:"fee"`

--- a/client/algod/wrappers.go
+++ b/client/algod/wrappers.go
@@ -108,6 +108,21 @@ func (client Client) TransactionInformation(accountAddress, transactionID string
 	return
 }
 
+// PendingTransactionInformation gets information about a recently issued
+// transaction.  There are several cases when this might succeed:
+//
+// - transaction committed (CommittedRound > 0)
+// - transaction still in the pool (CommittedRound = 0, PoolError = "")
+// - transaction removed from pool due to error (CommittedRound = 0, PoolError != "")
+//
+// Or the transaction may have happened sufficiently long ago that the
+// node no longer remembers it, and this will return an error.
+func (client Client) PendingTransactionInformation(transactionID string) (response models.Transaction, err error) {
+	transactionID = stripTransaction(transactionID)
+	err = client.get(&response, fmt.Sprintf("/transactions/pending/%s", transactionID), nil)
+	return
+}
+
 // TransactionByID gets a transaction by its ID. Works only if the indexer is enabled on the node
 // being queried.
 func (client Client) TransactionByID(transactionID string) (response models.Transaction, err error) {


### PR DESCRIPTION
This support is convenient to check whether a sent transaction has been committed to the ledger or not.