### PR TITLE
Add transactions group support

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -62,14 +62,9 @@ func rawTransactionBytesToSign(tx types.Transaction) []byte {
 	return bytes.Join(msgParts, nil)
 }
 
-// rawHash computes Sum512_256 hash from raw bytes
-func rawHash(input []byte) types.Digest {
-	return sha512.Sum512_256(input)
-}
-
 // txID computes a transaction id from raw transaction bytes
 func txIDFromRawTxnBytesToSign(toBeSigned []byte) (txid string) {
-	txidBytes := rawHash(toBeSigned)
+	txidBytes := sha512.Sum512_256(toBeSigned)
 	txid = base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(txidBytes[:])
 	return
 }
@@ -304,13 +299,13 @@ func ComputeGroupID(txgroup []types.Transaction) (gid types.Digest, err error) {
 			return
 		}
 
-		txID := rawHash(rawTransactionBytesToSign(tx))
-		group.Transactions = append(group.Transactions, txID)
+		txID := sha512.Sum512_256(rawTransactionBytesToSign(tx))
+		group.TxGroupHashes = append(group.TxGroupHashes, txID)
 	}
 
 	encoded := msgpack.Encode(group)
 
 	// Prepend the hashable prefix and hash it
 	msgParts := [][]byte{tgidPrefix, encoded}
-	return rawHash(bytes.Join(msgParts, nil)), nil
+	return sha512.Sum512_256(bytes.Join(msgParts, nil)), nil
 }

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"encoding/base32"
+	"fmt"
 	"golang.org/x/crypto/ed25519"
 
 	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
@@ -14,12 +15,14 @@ import (
 // txidPrefix is prepended to a transaction when computing its txid
 var txidPrefix = []byte("TX")
 
+// tgidPrefix is prepended to a transaction group when computing the group ID
+var tgidPrefix = []byte("TG")
+
 // bidPrefix is prepended to a bid when signing it
 var bidPrefix = []byte("aB")
 
 // bytesPrefix is prepended to a message when signing
 var bytesPrefix = []byte("MX")
-
 
 // RandomBytes fills the passed slice with randomness, and panics if it is
 // unable to do so
@@ -50,7 +53,7 @@ func SignTransaction(sk ed25519.PrivateKey, tx types.Transaction) (txid string, 
 
 // rawTransactionBytesToSign returns the byte form of the tx that we actually sign
 // and compute txID from.
-func rawTransactionBytesToSign(tx types.Transaction) ([]byte) {
+func rawTransactionBytesToSign(tx types.Transaction) []byte {
 	// Encode the transaction as msgpack
 	encodedTx := msgpack.Encode(tx)
 
@@ -59,9 +62,14 @@ func rawTransactionBytesToSign(tx types.Transaction) ([]byte) {
 	return bytes.Join(msgParts, nil)
 }
 
+// rawHash computes Sum512_256 hash from raw bytes
+func rawHash(input []byte) types.Digest {
+	return sha512.Sum512_256(input)
+}
+
 // txID computes a transaction id from raw transaction bytes
 func txIDFromRawTxnBytesToSign(toBeSigned []byte) (txid string) {
-	txidBytes := sha512.Sum512_256(toBeSigned)
+	txidBytes := rawHash(toBeSigned)
 	txid = base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(txidBytes[:])
 	return
 }
@@ -192,7 +200,7 @@ func SignMultisigTransaction(sk ed25519.PrivateKey, pk MultisigAccount, tx types
 	// Encode the signedTxn
 	stx := types.SignedTxn{
 		Msig: sig,
-		Txn: tx,
+		Txn:  tx,
 	}
 	stxBytes = msgpack.Encode(stx)
 	return
@@ -260,7 +268,7 @@ func MergeMultisigTransactions(stxsBytes ...[]byte) (txid string, stxBytes []byt
 	// Encode the signedTxn
 	stx := types.SignedTxn{
 		Msig: sig,
-		Txn: refTx,
+		Txn:  refTx,
 	}
 	stxBytes = msgpack.Encode(stx)
 	// let's also compute the txid.
@@ -284,4 +292,25 @@ func AppendMultisigTransaction(sk ed25519.PrivateKey, pk MultisigAccount, preStx
 	}
 	txid, stxBytes, err = MergeMultisigTransactions(partStxBytes, preStxBytes)
 	return
+}
+
+// ComputeGroupID returns group ID for a group of transactions
+func ComputeGroupID(txgroup []types.Transaction) (gid types.Digest, err error) {
+	var group types.TxGroup
+	empty := types.Digest{}
+	for _, tx := range txgroup {
+		if tx.Group != empty {
+			err = fmt.Errorf("transaction %v already has a group %v", tx, tx.Group)
+			return
+		}
+
+		txID := rawHash(rawTransactionBytesToSign(tx))
+		group.Transactions = append(group.Transactions, txID)
+	}
+
+	encoded := msgpack.Encode(group)
+
+	// Prepend the hashable prefix and hash it
+	msgParts := [][]byte{tgidPrefix, encoded}
+	return rawHash(bytes.Join(msgParts, nil)), nil
 }

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -8,7 +8,8 @@ import (
 	"github.com/algorand/go-algorand-sdk/types"
 )
 
-const MinTxnFee = 1000 // v5 consensus params, in microAlgos
+// MinTxnFee is v5 consensus params, in microAlgos
+const MinTxnFee = 1000
 
 // MakePaymentTxn constructs a payment transaction using the passed parameters.
 // `from` and `to` addresses should be checksummed, human-readable addresses

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -171,4 +171,17 @@ func TestComputeGroupID(t *testing.T) {
 	const goldenTxg = "gaN0eG6Lo2FtdM0H0KNmZWXNA+iiZnbOAArW/6NnZW6rZGV2bmV0LXYxLjCiZ2jEILAtz+3tknW6iiStLW4gnSvbXUqW3ul3ghinaDc5pY9Bo2dycMQgLiQ9OBup9H/bZLSfQUH2S6iHUM6FQ3PLuv9FNKyt09SibHbOAAra56Rub3RlxAjBErDlwnQIyqNyY3bEIKPwAqzyQ9iXHremmPXDnjXSqQxEZn0Vih81g9fEak0so3NuZMQgo/ACrPJD2Jcet6aY9cOeNdKpDERmfRWKHzWD18RqTSykdHlwZaNwYXmBo3R4boujYW10zQfQo2ZlZc0D6KJmds4ACtdzo2dlbqtkZXZuZXQtdjEuMKJnaMQgsC3P7e2SdbqKJK0tbiCdK9tdSpbe6XeCGKdoNzmlj0GjZ3JwxCAuJD04G6n0f9tktJ9BQfZLqIdQzoVDc8u6/0U0rK3T1KJsds4ACttbpG5vdGXECHQZRyOgXayIo3JjdsQgo/ACrPJD2Jcet6aY9cOeNdKpDERmfRWKHzWD18RqTSyjc25kxCCj8AKs8kPYlx63ppj1w5410qkMRGZ9FYofNYPXxGpNLKR0eXBlo3BheQ=="
 
 	require.Equal(t, byteFromBase64(goldenTxg), txg)
+
+	// check AssignGroupID, do not validate correctness of Group field calculation
+	result, err := AssignGroupID([]types.Transaction{tx1, tx2}, "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4")
+	require.NoError(t, err)
+	require.Equal(t, 0, len(result))
+
+	result, err = AssignGroupID([]types.Transaction{tx1, tx2}, address)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(result))
+
+	result, err = AssignGroupID([]types.Transaction{tx1, tx2}, "")
+	require.NoError(t, err)
+	require.Equal(t, 2, len(result))
 }

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand-sdk/crypto"
+	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
 	"github.com/algorand/go-algorand-sdk/mnemonic"
 	"github.com/algorand/go-algorand-sdk/types"
 )
@@ -119,4 +120,55 @@ func TestMakeKeyRegTxn(t *testing.T) {
 		},
 	}
 	require.Equal(t, expKeyRegTxn, tx)
+}
+
+func TestComputeGroupID(t *testing.T) {
+	// compare regular transactions created in SDK with 'goal clerk send' result
+	// compare transaction group created in SDK with 'goal clerk group' result
+	const address = "UPYAFLHSIPMJOHVXU2MPLQ46GXJKSDCEMZ6RLCQ7GWB5PRDKJUWKKXECXI"
+	const fromAddress, toAddress = address, address
+	const fee = 1000
+	const amount = 2000
+	const genesisID = "devnet-v1.0"
+	genesisHash := byteFromBase64("sC3P7e2SdbqKJK0tbiCdK9tdSpbe6XeCGKdoNzmlj0E=")
+
+	const firstRound1 = 710399
+	note1 := byteFromBase64("wRKw5cJ0CMo=")
+	tx1, err := MakePaymentTxnWithFlatFee(
+		fromAddress, toAddress, fee, amount, firstRound1, firstRound1+1000,
+		note1, "", genesisID, genesisHash,
+	)
+	require.NoError(t, err)
+
+	const firstRound2 = 710515
+	note2 := byteFromBase64("dBlHI6BdrIg=")
+	tx2, err := MakePaymentTxnWithFlatFee(
+		fromAddress, toAddress, fee, amount, firstRound2, firstRound2+1000,
+		note2, "", genesisID, genesisHash,
+	)
+	require.NoError(t, err)
+
+	const goldenTx1 = "gaN0eG6Ko2FtdM0H0KNmZWXNA+iiZnbOAArW/6NnZW6rZGV2bmV0LXYxLjCiZ2jEILAtz+3tknW6iiStLW4gnSvbXUqW3ul3ghinaDc5pY9Bomx2zgAK2uekbm90ZcQIwRKw5cJ0CMqjcmN2xCCj8AKs8kPYlx63ppj1w5410qkMRGZ9FYofNYPXxGpNLKNzbmTEIKPwAqzyQ9iXHremmPXDnjXSqQxEZn0Vih81g9fEak0spHR5cGWjcGF5"
+	const goldenTx2 = "gaN0eG6Ko2FtdM0H0KNmZWXNA+iiZnbOAArXc6NnZW6rZGV2bmV0LXYxLjCiZ2jEILAtz+3tknW6iiStLW4gnSvbXUqW3ul3ghinaDc5pY9Bomx2zgAK21ukbm90ZcQIdBlHI6BdrIijcmN2xCCj8AKs8kPYlx63ppj1w5410qkMRGZ9FYofNYPXxGpNLKNzbmTEIKPwAqzyQ9iXHremmPXDnjXSqQxEZn0Vih81g9fEak0spHR5cGWjcGF5"
+
+	// goal clerk send dumps unsigned transaction as signed with empty signature in order to save tx type
+	stx1 := types.SignedTxn{Sig: types.Signature{}, Msig: types.MultisigSig{}, Txn: tx1}
+	stx2 := types.SignedTxn{Sig: types.Signature{}, Msig: types.MultisigSig{}, Txn: tx2}
+	require.Equal(t, byteFromBase64(goldenTx1), msgpack.Encode(stx1))
+	require.Equal(t, byteFromBase64(goldenTx2), msgpack.Encode(stx2))
+
+	gid, err := crypto.ComputeGroupID([]types.Transaction{tx1, tx2})
+
+	// goal clerk group sets Group to every transaction and concatenate them in output file
+	// simulating that behavior here
+	stx1.Txn.Group = gid
+	stx2.Txn.Group = gid
+
+	var txg []byte
+	txg = append(txg, msgpack.Encode(stx1)...)
+	txg = append(txg, msgpack.Encode(stx2)...)
+
+	const goldenTxg = "gaN0eG6Lo2FtdM0H0KNmZWXNA+iiZnbOAArW/6NnZW6rZGV2bmV0LXYxLjCiZ2jEILAtz+3tknW6iiStLW4gnSvbXUqW3ul3ghinaDc5pY9Bo2dycMQgLiQ9OBup9H/bZLSfQUH2S6iHUM6FQ3PLuv9FNKyt09SibHbOAAra56Rub3RlxAjBErDlwnQIyqNyY3bEIKPwAqzyQ9iXHremmPXDnjXSqQxEZn0Vih81g9fEak0so3NuZMQgo/ACrPJD2Jcet6aY9cOeNdKpDERmfRWKHzWD18RqTSykdHlwZaNwYXmBo3R4boujYW10zQfQo2ZlZc0D6KJmds4ACtdzo2dlbqtkZXZuZXQtdjEuMKJnaMQgsC3P7e2SdbqKJK0tbiCdK9tdSpbe6XeCGKdoNzmlj0GjZ3JwxCAuJD04G6n0f9tktJ9BQfZLqIdQzoVDc8u6/0U0rK3T1KJsds4ACttbpG5vdGXECHQZRyOgXayIo3JjdsQgo/ACrPJD2Jcet6aY9cOeNdKpDERmfRWKHzWD18RqTSyjc25kxCCj8AKs8kPYlx63ppj1w5410qkMRGZ9FYofNYPXxGpNLKR0eXBlo3BheQ=="
+
+	require.Equal(t, byteFromBase64(goldenTxg), txg)
 }

--- a/types/basics.go
+++ b/types/basics.go
@@ -38,10 +38,12 @@ type Digest [hashLenBytes]byte
 
 const microAlgoConversionFactor = 1e6
 
+// ToAlgos converts amount in microAlgos to Algos
 func (microalgos MicroAlgos) ToAlgos() float64 {
 	return float64(microalgos) / microAlgoConversionFactor
 }
 
+// ToMicroAlgos converts amount in Algos to microAlgos
 func ToMicroAlgos(algos float64) MicroAlgos {
 	return MicroAlgos(math.Round(algos * microAlgoConversionFactor))
 }

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -61,4 +61,21 @@ type Header struct {
 	Note        []byte     `codec:"note"`
 	GenesisID   string     `codec:"gen"`
 	GenesisHash Digest     `codec:"gh"`
+
+	// Group specifies that this transaction is part of a
+	// transaction group (and, if so, specifies the hash
+	// of a TxGroup).
+	Group Digest `codec:"grp"`
+}
+
+// TxGroup describes a group of transactions that must appear
+// together in a specific order in a block.
+type TxGroup struct {
+	_struct struct{} `codec:",omitempty,omitemptyarray"`
+
+	// Transactions specifies a list of transactions that must appear
+	// together, sequentially, in a block in order for the group to be
+	// valid.  Each hash in the list is a hash of a transaction with
+	// the `Group` field omitted.
+	Transactions []Digest `codec:"txlist"`
 }

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -73,9 +73,9 @@ type Header struct {
 type TxGroup struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	// Transactions specifies a list of transactions that must appear
+	// TxGroupHashes specifies a list of hashes of transactions that must appear
 	// together, sequentially, in a block in order for the group to be
 	// valid.  Each hash in the list is a hash of a transaction with
 	// the `Group` field omitted.
-	Transactions []Digest `codec:"txlist"`
+	TxGroupHashes []Digest `codec:"txlist"`
 }


### PR DESCRIPTION
* New ComputeGroupID return group ID for group of transactions
* TestComputeGroupID verified group ID agains 'goal clerk group' output
* README contains usage example

Note, no special SendTransaction function added because SendRawTransaction works great and there not API to get SignedTxn object from signing functions.