### PR TITLE
Helpers for making Asset Freeze/Un-freeze transactions

### DIFF
--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -202,7 +202,36 @@ func TestMakeAssetConfigTxn(t *testing.T) {
 }
 
 func TestMakeAssetFreezeTxn(t *testing.T) {
-	t.FailNow() // fail until I fix this :) TODO EJR
+	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
+	const genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+	const creator = addr
+	const assetIndex = 1
+	const firstValidRound = 322575
+	const lastValidRound = 323575
+	const freezeSetting = true
+	const target = creator
+	tx, err := MakeAssetFreezeTxn(creator, 10, firstValidRound, lastValidRound, nil, "", genesisHash, creator, assetIndex, target, freezeSetting)
+	require.NoError(t, err)
+
+	a, err := types.DecodeAddress(creator)
+	require.NoError(t, err)
+	expectedAssetFreezeTxn := types.Transaction{
+		Type: types.AssetFreezeTx,
+		Header: types.Header{
+			Sender:      a,
+			Fee:         2720,
+			FirstValid:  firstValidRound,
+			LastValid:   lastValidRound,
+			GenesisHash: byte32ArrayFromBase64(genesisHash),
+			GenesisID:   "",
+		},
+	}
+
+	expectedAssetFreezeTxn.FreezeAsset.Creator = a
+	expectedAssetFreezeTxn.FreezeAsset.Index = assetIndex
+	expectedAssetFreezeTxn.AssetFrozen = freezeSetting
+	expectedAssetFreezeTxn.FreezeAccount = a
+	require.Equal(t, expectedAssetFreezeTxn, tx)
 }
 
 func TestComputeGroupID(t *testing.T) {

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/algorand/go-algorand-sdk/crypto"
 	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
 	"github.com/algorand/go-algorand-sdk/mnemonic"
@@ -197,6 +199,10 @@ func TestMakeAssetConfigTxn(t *testing.T) {
 		Index:   1234,
 	}
 	require.Equal(t, expectedAssetConfigTxn, tx)
+}
+
+func TestMakeAssetFreezeTxn(t *testing.T) {
+	t.FailNow() // fail until I fix this :) TODO EJR
 }
 
 func TestComputeGroupID(t *testing.T) {

--- a/types/basics.go
+++ b/types/basics.go
@@ -16,6 +16,8 @@ const (
 	KeyRegistrationTx TxType = "keyreg"
 	// AssetConfigTx creates, re-configures, or destroys an asset
 	AssetConfigTx TxType = "acfg"
+	// AssetFreezeTx changes the freeze status of an asset
+	AssetFreezeTx TxType = "afrz"
 )
 
 const masterDerivationKeyLenBytes = 32

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -14,6 +14,7 @@ type Transaction struct {
 	KeyregTxnFields
 	PaymentTxnFields
 	AssetConfigTxnFields
+	AssetFreezeTxnFields
 }
 
 // SignedTxn wraps a transaction and a signature. The encoding of this struct


### PR DESCRIPTION
## Summary
This PR proposes to add the ability to make asset freeze/un-freeze transactions. These transactions must be issued by the asset's freeze-manager. It includes both a feePerByte and a flat-fee version.

### Testing
Unit test added to `transaction_test.go`.