### PR TITLE
Asset Transfer Transactions, and related operations: acceptance, revocation, burning, minting

### DIFF
--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -435,6 +435,22 @@ func MakeAssetTransferTxn(account, recipient, closeAssetsTo string, amount, feeP
 	return tx, nil
 }
 
+// MakeAssetAcceptanceTransaction creates a tx for marking an asset as willing to be accepted by an account
+// - account is a checksummed, human-readable address that will send the transaction and begin accepting the asset
+// - feePerByte is a fee per byte
+// - firstRound is the first round this txn is valid (txn semantics unrelated to asset management)
+// - lastRound is the last round this txn is valid
+// - genesis id corresponds to the id of the network
+// - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - creator is the address of the asset creator
+// - index is the asset index
+func MakeAssetAcceptanceTransaction(account string, feePerByte, firstRound, lastRound uint64, note []byte,
+	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
+	tx, err := MakeAssetTransferTxn(account, account, "", 0,
+		feePerByte, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
+	return tx, err
+}
+
 // MakeAssetDestroyTxn creates a tx template for destroying an asset, removing it from the record.
 // All outstanding asset amount must be held by the creator, and this transaction must be issued by the asset manager.
 // - account is a checksummed, human-readable address that will send the transaction; it also must be the asset manager

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -507,6 +507,46 @@ func MakeAssetRevocationTransaction(account, target, recipient string, amount, f
 	return tx, err
 }
 
+// MakeAssetMintTransaction creates a tx for minting more of an asset (transferring from the reserve account)
+// Note that this is just an asset transfer transaction where sender=reserve
+// - reserve is a checksummed, human-readable address that will send the transaction. it must be the asset's reserve to be considered a minting, but this is not enforced by the function.
+// - recipient is a checksummed, human-readable address; it will receive the revoked assets
+// - amount is the number of assets to mint
+// - feePerByte is a fee per byte
+// - firstRound is the first round this txn is valid (txn semantics unrelated to asset management)
+// - lastRound is the last round this txn is valid
+// - note is an arbitrary byte array
+// - genesis id corresponds to the id of the network
+// - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - creator is the address of the asset creator
+// - index is the asset index
+func MakeAssetMintTransaction(reserve, recipient string, amount, feePerByte, firstRound, lastRound uint64, note []byte,
+	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
+	tx, err := MakeAssetTransferTxn(reserve, recipient, "", amount,
+		feePerByte, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
+	return tx, err
+}
+
+// MakeAssetBurnTransaction creates for burning an asset (transferring to the reserve account)
+// Note that this is just an asset transfer transaction where recipient=reserve
+// - account is a checksummed, human-readable address that will send the transaction.
+// - reserve is a checksummed, human-readable address; it will receive the revoked assets and must be the reserve account to be considered a burn. this is not enforced by the function
+// - amount is the number of assets to "burn"
+// - feePerByte is a fee per byte
+// - firstRound is the first round this txn is valid (txn semantics unrelated to asset management)
+// - lastRound is the last round this txn is valid
+// - note is an arbitrary byte array
+// - genesis id corresponds to the id of the network
+// - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - creator is the address of the asset creator
+// - index is the asset index
+func MakeAssetBurnTransaction(account, reserve string, amount, feePerByte, firstRound, lastRound uint64, note []byte,
+	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
+	tx, err := MakeAssetTransferTxn(account, reserve, "", amount,
+		feePerByte, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
+	return tx, err
+}
+
 // MakeAssetDestroyTxn creates a tx template for destroying an asset, removing it from the record.
 // All outstanding asset amount must be held by the creator, and this transaction must be issued by the asset manager.
 // - account is a checksummed, human-readable address that will send the transaction; it also must be the asset manager
@@ -724,6 +764,66 @@ func MakeAssetRevocationTransactionWithFlatFee(account, target, recipient string
 		tx.Fee = MinTxnFee
 	}
 	return tx, nil
+}
+
+// MakeAssetMintTransactionWithFlatFee creates a tx for minting more of an asset (transferring from the reserve account)
+// Note that this is just an asset transfer transaction where sender=reserve
+// - reserve is a checksummed, human-readable address that will send the transaction. it must be the asset's reserve to be considered a minting, but this is not enforced by the function.
+// - recipient is a checksummed, human-readable address; it will receive the revoked assets
+// - amount is the number of assets to send
+// - fee is the flat fee
+// - firstRound is the first round this txn is valid (txn semantics unrelated to asset management)
+// - lastRound is the last round this txn is valid
+// - note is an arbitrary byte array
+// - genesis id corresponds to the id of the network
+// - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - creator is the address of the asset creator
+// - index is the asset index
+func MakeAssetMintTransactionWithFlatFee(reserve, recipient string, amount, fee, firstRound, lastRound uint64, note []byte,
+	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
+	tx, err := MakeAssetMintTransaction(reserve, recipient, amount,
+		fee, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
+
+	if err != nil {
+		return types.Transaction{}, err
+	}
+
+	tx.Fee = types.MicroAlgos(fee)
+
+	if tx.Fee < MinTxnFee {
+		tx.Fee = MinTxnFee
+	}
+	return tx, err
+}
+
+// MakeAssetBurnTransactionWithFlatFee creates for burning an asset (transferring to the reserve account)
+// Note that this is just an asset transfer transaction where recipient=reserve
+// - account is a checksummed, human-readable address that will send the transaction.
+// - reserve is a checksummed, human-readable address; it will receive the revoked assets and must be the reserve account to be considered a burn. this is not enforced by the function
+// - amount is the number of assets to send
+// - fee is the flat fee
+// - firstRound is the first round this txn is valid (txn semantics unrelated to asset management)
+// - lastRound is the last round this txn is valid
+// - note is an arbitrary byte array
+// - genesis id corresponds to the id of the network
+// - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - creator is the address of the asset creator
+// - index is the asset index
+func MakeAssetBurnTransactionWithFlatFee(account, reserve string, amount, fee, firstRound, lastRound uint64, note []byte,
+	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
+	tx, err := MakeAssetBurnTransaction(account, reserve, amount,
+		fee, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
+
+	if err != nil {
+		return types.Transaction{}, err
+	}
+
+	tx.Fee = types.MicroAlgos(fee)
+
+	if tx.Fee < MinTxnFee {
+		tx.Fee = MinTxnFee
+	}
+	return tx, err
 }
 
 // MakeAssetDestroyTxnWithFlatFee creates a tx template for destroying an asset, removing it from the record.

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -463,7 +463,7 @@ func MakeAssetTransferTxn(account, recipient, closeAssetsTo string, amount, feeP
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // - creator is the address of the asset creator
 // - index is the asset index
-func MakeAssetAcceptanceTransaction(account string, feePerByte, firstRound, lastRound uint64, note []byte,
+func MakeAssetAcceptanceTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
 	tx, err := MakeAssetTransferTxn(account, account, "", 0,
 		feePerByte, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
@@ -482,7 +482,7 @@ func MakeAssetAcceptanceTransaction(account string, feePerByte, firstRound, last
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // - creator is the address of the asset creator
 // - index is the asset index
-func MakeAssetRevocationTransaction(account, target, recipient string, amount, feePerByte, firstRound, lastRound uint64, note []byte,
+func MakeAssetRevocationTxn(account, target, recipient string, amount, feePerByte, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
 	tx, err := MakeAssetTransferTxn(account, recipient, "", amount,
 		feePerByte, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
@@ -520,7 +520,7 @@ func MakeAssetRevocationTransaction(account, target, recipient string, amount, f
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // - creator is the address of the asset creator
 // - index is the asset index
-func MakeAssetMintTransaction(reserve, recipient string, amount, feePerByte, firstRound, lastRound uint64, note []byte,
+func MakeAssetMintTxn(reserve, recipient string, amount, feePerByte, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
 	tx, err := MakeAssetTransferTxn(reserve, recipient, "", amount,
 		feePerByte, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
@@ -540,7 +540,7 @@ func MakeAssetMintTransaction(reserve, recipient string, amount, feePerByte, fir
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // - creator is the address of the asset creator
 // - index is the asset index
-func MakeAssetBurnTransaction(account, reserve string, amount, feePerByte, firstRound, lastRound uint64, note []byte,
+func MakeAssetBurnTxn(account, reserve string, amount, feePerByte, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
 	tx, err := MakeAssetTransferTxn(account, reserve, "", amount,
 		feePerByte, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
@@ -723,7 +723,7 @@ func MakeAssetTransferTxnWithFlatFee(account, recipient, closeAssetsTo string, a
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // - creator is the address of the asset creator
 // - index is the asset index
-func MakeAssetAcceptanceTransactionWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte,
+func MakeAssetAcceptanceTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
 	tx, err := MakeAssetTransferTxnWithFlatFee(account, account, "", 0,
 		fee, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
@@ -742,9 +742,9 @@ func MakeAssetAcceptanceTransactionWithFlatFee(account string, fee, firstRound, 
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // - creator is the address of the asset creator
 // - index is the asset index
-func MakeAssetRevocationTransactionWithFlatFee(account, target, recipient string, amount, fee, firstRound, lastRound uint64, note []byte,
+func MakeAssetRevocationTxnWithFlatFee(account, target, recipient string, amount, fee, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
-	tx, err := MakeAssetRevocationTransaction(account, target, recipient, amount, fee, firstRound, lastRound,
+	tx, err := MakeAssetRevocationTxn(account, target, recipient, amount, fee, firstRound, lastRound,
 		note, genesisID, genesisHash, creator, index)
 
 	if err != nil {
@@ -772,7 +772,7 @@ func MakeAssetRevocationTransactionWithFlatFee(account, target, recipient string
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // - creator is the address of the asset creator
 // - index is the asset index
-func MakeAssetMintTransactionWithFlatFee(reserve, recipient string, amount, fee, firstRound, lastRound uint64, note []byte,
+func MakeAssetMintTxnWithFlatFee(reserve, recipient string, amount, fee, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
 	tx, err := MakeAssetTransferTxnWithFlatFee(reserve, recipient, "", amount,
 		fee, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
@@ -792,7 +792,7 @@ func MakeAssetMintTransactionWithFlatFee(reserve, recipient string, amount, fee,
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // - creator is the address of the asset creator
 // - index is the asset index
-func MakeAssetBurnTransactionWithFlatFee(account, reserve string, amount, fee, firstRound, lastRound uint64, note []byte,
+func MakeAssetBurnTxnWithFlatFee(account, reserve string, amount, fee, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
 	tx, err := MakeAssetTransferTxnWithFlatFee(account, reserve, "", amount,
 		fee, firstRound, lastRound, note, genesisID, genesisHash, creator, index)

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -453,7 +453,7 @@ func MakeAssetTransferTxn(account, recipient, closeAssetsTo string, amount, feeP
 	return tx, nil
 }
 
-// MakeAssetAcceptanceTransaction creates a tx for marking an asset as willing to be accepted by an account
+// MakeAssetAcceptanceTransaction creates a tx for marking an account as willing to accept the given asset
 // - account is a checksummed, human-readable address that will send the transaction and begin accepting the asset
 // - feePerByte is a fee per byte
 // - firstRound is the first round this txn is valid (txn semantics unrelated to asset management)

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -609,6 +609,30 @@ func MakeAssetTransferTxnWithFlatFee(account, recipient, closeAssetsTo string, a
 	return tx, nil
 }
 
+// MakeAssetAcceptanceTransactionWithFlatFee creates a tx for marking an asset as willing to be accepted by an account
+// - account is a checksummed, human-readable address that will send the transaction and begin accepting the asset
+// - fee is a flat fee
+// - firstRound is the first round this txn is valid (txn semantics unrelated to asset management)
+// - lastRound is the last round this txn is valid
+// - genesis id corresponds to the id of the network
+// - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - creator is the address of the asset creator
+// - index is the asset index
+func MakeAssetAcceptanceTransactionWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte,
+	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
+	tx, err := MakeAssetAcceptanceTransaction(account, fee, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
+	if err != nil {
+		return types.Transaction{}, err
+	}
+
+	tx.Fee = types.MicroAlgos(fee)
+
+	if tx.Fee < MinTxnFee {
+		tx.Fee = MinTxnFee
+	}
+	return tx, nil
+}
+
 // MakeAssetDestroyTxn creates a tx template for destroying an asset, removing it from the record.
 // All outstanding asset amount must be held by the creator, and this transaction must be issued by the asset manager.
 // - account is a checksummed, human-readable address that will send the transaction; it also must be the asset manager

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -374,7 +374,7 @@ func MakeAssetConfigTxn(account string, feePerByte, firstRound, lastRound uint64
 }
 
 // MakeAssetTransferTxn creates a tx for sending some asset from an asset holder to another user
-// the recipient must have marked themselves as willing to accept the asset
+// the recipient address must have previously issued an asset acceptance transaction for this asset
 // - account is a checksummed, human-readable address that will send the transaction and assets
 // - recipient is a checksummed, human-readable address what will receive the assets
 // - closeAssetsTo is a checksummed, human-readable address that behaves as a close-to address for the asset transaction; the remaining assets not sent to recipient will be sent to closeAssetsTo. Leave blank for no close-to behavior.
@@ -686,7 +686,7 @@ func MakeAssetConfigTxnWithFlatFee(account string, fee, firstRound, lastRound ui
 }
 
 // MakeAssetTransferTxnWithFlatFee creates a tx for sending some asset from an asset holder to another user
-// the recipient must have marked themselves as willing to accept the asset
+// the recipient address must have previously issued an asset acceptance transaction for this asset
 // - account is a checksummed, human-readable address that will send the transaction and assets
 // - recipient is a checksummed, human-readable address what will receive the assets
 // - closeAssetsTo is a checksummed, human-readable address that behaves as a close-to address for the asset transaction; the remaining assets not sent to recipient will be sent to closeAssetsTo. Leave blank for no close-to behavior.
@@ -713,7 +713,7 @@ func MakeAssetTransferTxnWithFlatFee(account, recipient, closeAssetsTo string, a
 	return tx, nil
 }
 
-// MakeAssetAcceptanceTransactionWithFlatFee creates a tx for marking an asset as willing to be accepted by an account
+// MakeAssetAcceptanceTransactionWithFlatFee creates a tx for marking an account as willing to accept an asset
 // - account is a checksummed, human-readable address that will send the transaction and begin accepting the asset
 // - fee is a flat fee
 // - firstRound is the first round this txn is valid (txn semantics unrelated to asset management)

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -803,16 +803,6 @@ func MakeAssetBurnTransactionWithFlatFee(account, reserve string, amount, fee, f
 	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
 	tx, err := MakeAssetTransferTxnWithFlatFee(account, reserve, "", amount,
 		fee, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
-
-	if err != nil {
-		return types.Transaction{}, err
-	}
-
-	tx.Fee = types.MicroAlgos(fee)
-
-	if tx.Fee < MinTxnFee {
-		tx.Fee = MinTxnFee
-	}
 	return tx, err
 }
 

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -284,16 +284,22 @@ func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64
 }
 
 // MakeAssetConfigTxn creates a tx template for changing the
-// key configuration for an existing asset. An empty string means
-// a zero key (which cannot be changed after becoming zero);
-// to keep a key unchanged, you must specify that key.
+// key configuration of an existing asset.
+// Important notes -
+// 	* Every asset config transaction is a fresh one. No parameters will be inherited from the current config.
+// 	* Once an address is set to to the empty string, IT CAN NEVER BE CHANGED AGAIN. For example, if you want to keep
+//    The current manager, you must specify its address again.
+//	Parameters -
 // - account is a checksummed, human-readable address that will send the transaction
-// - fee is a fee per byte
+// - feePerByte  is a fee per byte
 // - firstRound is the first round this txn is valid (txn semantics unrelated to asset config)
 // - lastRound is the last round this txn is valid
 // - note is an arbitrary byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - creator the address of the asset creator
+// - index is the asset index id
+// - for newManager, newReserve, newFreeze, newClawback see asset.go
 func MakeAssetConfigTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID string, genesisHash string, creator string,
 	index uint64, newManager, newReserve, newFreeze, newClawback string) (types.Transaction, error) {
 	var tx types.Transaction
@@ -315,7 +321,7 @@ func MakeAssetConfigTxn(account string, feePerByte, firstRound, lastRound uint64
 		Fee:         types.MicroAlgos(feePerByte),
 		FirstValid:  types.Round(firstRound),
 		LastValid:   types.Round(lastRound),
-		GenesisHash: types.Digest(ghBytes),
+		GenesisHash: ghBytes,
 		GenesisID:   genesisID,
 		Note:        note,
 	}

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -700,7 +700,8 @@ func MakeAssetConfigTxnWithFlatFee(account string, fee, firstRound, lastRound ui
 // - index is the asset index
 func MakeAssetTransferTxnWithFlatFee(account, recipient, closeAssetsTo string, amount, fee, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
-	tx, err := MakeAssetTransferTxn(account, recipient, closeAssetsTo, amount, fee, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
+	tx, err := MakeAssetTransferTxn(account, recipient, closeAssetsTo, amount,
+		fee, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -724,17 +725,9 @@ func MakeAssetTransferTxnWithFlatFee(account, recipient, closeAssetsTo string, a
 // - index is the asset index
 func MakeAssetAcceptanceTransactionWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
-	tx, err := MakeAssetAcceptanceTransaction(account, fee, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
-	if err != nil {
-		return types.Transaction{}, err
-	}
-
-	tx.Fee = types.MicroAlgos(fee)
-
-	if tx.Fee < MinTxnFee {
-		tx.Fee = MinTxnFee
-	}
-	return tx, nil
+	tx, err := MakeAssetTransferTxnWithFlatFee(account, account, "", 0,
+		fee, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
+	return tx, err
 }
 
 // MakeAssetRevocationTransactionWithFlatFee creates a tx for revoking an asset from an account and sending it to another

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -268,12 +268,18 @@ func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64
 		GenesisID:   genesisID,
 		Note:        note,
 	}
+
 	// Update fee
 	eSize, err := estimateSize(tx)
 	if err != nil {
 		return types.Transaction{}, err
 	}
 	tx.Fee = types.MicroAlgos(eSize * feePerByte)
+
+	if tx.Fee < MinTxnFee {
+		tx.Fee = MinTxnFee
+	}
+
 	return tx, nil
 }
 
@@ -360,6 +366,10 @@ func MakeAssetConfigTxn(account string, feePerByte, firstRound, lastRound uint64
 	}
 	tx.Fee = types.MicroAlgos(eSize * feePerByte)
 
+	if tx.Fee < MinTxnFee {
+		tx.Fee = MinTxnFee
+	}
+
 	return tx, nil
 }
 
@@ -436,6 +446,10 @@ func MakeAssetTransferTxn(account, recipient, closeAssetsTo string, amount, feeP
 	}
 	tx.Fee = types.MicroAlgos(eSize * feePerByte)
 
+	if tx.Fee < MinTxnFee {
+		tx.Fee = MinTxnFee
+	}
+
 	return tx, nil
 }
 
@@ -484,7 +498,11 @@ func MakeAssetRevocationTransaction(account, target, recipient string, amount, f
 	if err != nil {
 		return types.Transaction{}, err
 	}
+
 	tx.Fee = types.MicroAlgos(eSize * feePerByte)
+	if tx.Fee < MinTxnFee {
+		tx.Fee = MinTxnFee
+	}
 
 	return tx, err
 }
@@ -504,12 +522,16 @@ func MakeAssetDestroyTxn(account string, feePerByte, firstRound, lastRound uint6
 	// an asset destroy transaction is just a configuration transaction with AssetParams zeroed
 	tx, err := MakeAssetConfigTxn(account, feePerByte, firstRound, lastRound, note, genesisID, genesisHash,
 		creator, index, "", "", "", "")
+
 	// Update fee
 	eSize, err := estimateSize(tx)
 	if err != nil {
 		return types.Transaction{}, err
 	}
 	tx.Fee = types.MicroAlgos(eSize * feePerByte)
+	if tx.Fee < MinTxnFee {
+		tx.Fee = MinTxnFee
+	}
 
 	return tx, nil
 }
@@ -571,6 +593,10 @@ func MakeAssetFreezeTxn(account string, fee, firstRound, lastRound uint64, note 
 		return types.Transaction{}, err
 	}
 	tx.Fee = types.MicroAlgos(eSize * fee)
+
+	if tx.Fee < MinTxnFee {
+		tx.Fee = MinTxnFee
+	}
 
 	return tx, nil
 }

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -284,9 +284,9 @@ func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64
 }
 
 // MakeAssetConfigTxn creates a tx template for changing the
-// keys for an asset. An empty string means a zero key (which
-// cannot be changed after becoming zero); to keep a key
-// unchanged, you must specify that key.
+// key configuration for an existing asset. An empty string means
+// a zero key (which cannot be changed after becoming zero);
+// to keep a key unchanged, you must specify that key.
 // - account is a checksummed, human-readable address that will send the transaction
 // - fee is a fee per byte
 // - firstRound is the first round this txn is valid (txn semantics unrelated to asset config)

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -781,18 +781,8 @@ func MakeAssetRevocationTransactionWithFlatFee(account, target, recipient string
 // - index is the asset index
 func MakeAssetMintTransactionWithFlatFee(reserve, recipient string, amount, fee, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
-	tx, err := MakeAssetMintTransaction(reserve, recipient, amount,
+	tx, err := MakeAssetTransferTxnWithFlatFee(reserve, recipient, "", amount,
 		fee, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
-
-	if err != nil {
-		return types.Transaction{}, err
-	}
-
-	tx.Fee = types.MicroAlgos(fee)
-
-	if tx.Fee < MinTxnFee {
-		tx.Fee = MinTxnFee
-	}
 	return tx, err
 }
 
@@ -811,7 +801,7 @@ func MakeAssetMintTransactionWithFlatFee(reserve, recipient string, amount, fee,
 // - index is the asset index
 func MakeAssetBurnTransactionWithFlatFee(account, reserve string, amount, fee, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
-	tx, err := MakeAssetBurnTransaction(account, reserve, amount,
+	tx, err := MakeAssetTransferTxnWithFlatFee(account, reserve, "", amount,
 		fee, firstRound, lastRound, note, genesisID, genesisHash, creator, index)
 
 	if err != nil {

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -276,6 +276,11 @@ func TestMakeAssetAcceptanceTxn(t *testing.T) {
 	require.True(t, false)
 }
 
+func TestMakeAssetRevocationTransaction(t *testing.T) {
+	// TODO ejr always fail for now
+	require.True(t, false)
+}
+
 func TestComputeGroupID(t *testing.T) {
 	// compare regular transactions created in SDK with 'goal clerk send' result
 	// compare transaction group created in SDK with 'goal clerk group' result

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -325,7 +325,7 @@ func TestMakeAssetAcceptanceTxn(t *testing.T) {
 	const lastValidRound = 323575
 	const amountToSend = 1
 
-	tx, err := MakeAssetAcceptanceTransaction(sender, 10, firstValidRound,
+	tx, err := MakeAssetAcceptanceTxn(sender, 10, firstValidRound,
 		lastValidRound, nil, "", genesisHash, creator, assetIndex)
 	require.NoError(t, err)
 
@@ -367,7 +367,7 @@ func TestMakeAssetRevocationTransaction(t *testing.T) {
 	const lastValidRound = 323575
 	const amountToSend = 1
 
-	tx, err := MakeAssetRevocationTransaction(revoker, revoked, recipient, amountToSend, 10, firstValidRound,
+	tx, err := MakeAssetRevocationTxn(revoker, revoked, recipient, amountToSend, 10, firstValidRound,
 		lastValidRound, nil, "", genesisHash, creator, assetIndex)
 	require.NoError(t, err)
 
@@ -409,13 +409,95 @@ func TestMakeAssetRevocationTransaction(t *testing.T) {
 }
 
 func TestMakeAssetMintTransaction(t *testing.T) {
-	// TODO ejr always fail for now
-	require.True(t, false)
+	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
+	const genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+	const reserve, recipient, creator = addr, addr, addr
+	const assetIndex = 1
+	const firstValidRound = 322575
+	const lastValidRound = 323575
+	const amountToSend = 1
+
+	tx, err := MakeAssetMintTxn(reserve, recipient, amountToSend, 10, firstValidRound,
+		lastValidRound, nil, "", genesisHash, creator, assetIndex)
+	require.NoError(t, err)
+
+	sendAddr, err := types.DecodeAddress(reserve)
+	require.NoError(t, err)
+
+	expectedAssetMintTxn := types.Transaction{
+		Type: types.AssetTransferTx,
+		Header: types.Header{
+			Sender:      sendAddr,
+			Fee:         2730,
+			FirstValid:  firstValidRound,
+			LastValid:   lastValidRound,
+			GenesisHash: byte32ArrayFromBase64(genesisHash),
+			GenesisID:   "",
+		},
+	}
+
+	creatorAddr, err := types.DecodeAddress(creator)
+	require.NoError(t, err)
+
+	expectedAssetID := types.AssetID{
+		Creator: creatorAddr,
+		Index:   assetIndex,
+	}
+	expectedAssetMintTxn.XferAsset = expectedAssetID
+
+	receiveAddr, err := types.DecodeAddress(recipient)
+	require.NoError(t, err)
+	expectedAssetMintTxn.AssetReceiver = receiveAddr
+
+	expectedAssetMintTxn.AssetAmount = amountToSend
+
+	require.Equal(t, expectedAssetMintTxn, tx)
 }
 
 func TestMakeAssetBurnTransaction(t *testing.T) {
-	// TODO ejr always fail for now
-	require.True(t, false)
+	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
+	const genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+	const reserve, sender, creator = addr, addr, addr
+	const assetIndex = 1
+	const firstValidRound = 322575
+	const lastValidRound = 323575
+	const amountToSend = 1
+
+	tx, err := MakeAssetBurnTxn(sender, reserve, amountToSend, 10, firstValidRound,
+		lastValidRound, nil, "", genesisHash, creator, assetIndex)
+	require.NoError(t, err)
+
+	sendAddr, err := types.DecodeAddress(sender)
+	require.NoError(t, err)
+
+	expectedAssetBurnTxn := types.Transaction{
+		Type: types.AssetTransferTx,
+		Header: types.Header{
+			Sender:      sendAddr,
+			Fee:         2730,
+			FirstValid:  firstValidRound,
+			LastValid:   lastValidRound,
+			GenesisHash: byte32ArrayFromBase64(genesisHash),
+			GenesisID:   "",
+		},
+	}
+
+	creatorAddr, err := types.DecodeAddress(creator)
+	require.NoError(t, err)
+
+	expectedAssetID := types.AssetID{
+		Creator: creatorAddr,
+		Index:   assetIndex,
+	}
+	expectedAssetBurnTxn.XferAsset = expectedAssetID
+
+	receiveAddr, err := types.DecodeAddress(reserve)
+	require.NoError(t, err)
+	expectedAssetBurnTxn.AssetReceiver = receiveAddr
+
+	expectedAssetBurnTxn.AssetAmount = amountToSend
+
+	require.Equal(t, expectedAssetBurnTxn, tx)
 }
 
 func TestComputeGroupID(t *testing.T) {

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -239,7 +239,7 @@ func TestMakeAssetFreezeTxn(t *testing.T) {
 	const creator = addr
 	const assetIndex = 1
 	const firstValidRound = 322575
-	const lastValidRound = 323575
+	const lastValidRound = 323576
 	const freezeSetting = true
 	const target = creator
 	tx, err := MakeAssetFreezeTxn(creator, 10, firstValidRound, lastValidRound, nil, "", genesisHash, creator, assetIndex, target, freezeSetting)
@@ -264,6 +264,13 @@ func TestMakeAssetFreezeTxn(t *testing.T) {
 	expectedAssetFreezeTxn.AssetFrozen = freezeSetting
 	expectedAssetFreezeTxn.FreezeAccount = a
 	require.Equal(t, expectedAssetFreezeTxn, tx)
+
+	const addrSK = "awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred"
+	private, err := mnemonic.ToPrivateKey(addrSK)
+	require.NoError(t, err)
+	_, newStxBytes, err := crypto.SignTransaction(private, tx)
+	signedGolden := "gqNzaWfEQJsNp4Hm5qYBN1Foa8nGd3zeMFxGFJiAxuf3/L1A4MTgR521fId0nIYtMwbJha5zRpN/0UuNoq91IkOK7LVhzACjdHhuiaRhZnJ6w6RmYWRkxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aRmYWlkgqFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFpAaNmZWXNCqCiZnbOAATsD6JnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAATv+KNzbmTEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pHR5cGWkYWZyeg=="
+	require.EqualValues(t, newStxBytes, byteFromBase64(signedGolden))
 }
 
 func TestMakeAssetTransferTxn(t *testing.T) {

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -317,8 +317,45 @@ func TestMakeAssetTransferTxn(t *testing.T) {
 }
 
 func TestMakeAssetAcceptanceTxn(t *testing.T) {
-	// TODO ejr always fail for now
-	require.True(t, false)
+	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
+	const genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+	const sender, creator = addr, addr
+	const assetIndex = 1
+	const firstValidRound = 322575
+	const lastValidRound = 323575
+	const amountToSend = 1
+
+	tx, err := MakeAssetAcceptanceTransaction(sender, 10, firstValidRound,
+		lastValidRound, nil, "", genesisHash, creator, assetIndex)
+	require.NoError(t, err)
+
+	sendAddr, err := types.DecodeAddress(sender)
+	require.NoError(t, err)
+
+	expectedAssetAcceptanceTxn := types.Transaction{
+		Type: types.AssetTransferTx,
+		Header: types.Header{
+			Sender:      sendAddr,
+			Fee:         2670,
+			FirstValid:  firstValidRound,
+			LastValid:   lastValidRound,
+			GenesisHash: byte32ArrayFromBase64(genesisHash),
+			GenesisID:   "",
+		},
+	}
+
+	creatorAddr, err := types.DecodeAddress(creator)
+	require.NoError(t, err)
+
+	expectedAssetID := types.AssetID{
+		Creator: creatorAddr,
+		Index:   assetIndex,
+	}
+	expectedAssetAcceptanceTxn.XferAsset = expectedAssetID
+	expectedAssetAcceptanceTxn.AssetReceiver = sendAddr
+	expectedAssetAcceptanceTxn.AssetAmount = 0
+
+	require.Equal(t, expectedAssetAcceptanceTxn, tx)
 }
 
 func TestMakeAssetRevocationTransaction(t *testing.T) {

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -281,6 +281,16 @@ func TestMakeAssetRevocationTransaction(t *testing.T) {
 	require.True(t, false)
 }
 
+func TestMakeAssetMintTransaction(t *testing.T) {
+	// TODO ejr always fail for now
+	require.True(t, false)
+}
+
+func TestMakeAssetBurnTransaction(t *testing.T) {
+	// TODO ejr always fail for now
+	require.True(t, false)
+}
+
 func TestComputeGroupID(t *testing.T) {
 	// compare regular transactions created in SDK with 'goal clerk send' result
 	// compare transaction group created in SDK with 'goal clerk group' result

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -272,7 +272,7 @@ func TestMakeAssetTransferTxn(t *testing.T) {
 	const sender, recipient, creator, closeAssetsTo = addr, addr, addr, addr
 	const assetIndex = 1
 	const firstValidRound = 322575
-	const lastValidRound = 323575
+	const lastValidRound = 323576
 	const amountToSend = 1
 
 	tx, err := MakeAssetTransferTxn(sender, recipient, closeAssetsTo, amountToSend, 10, firstValidRound,
@@ -314,6 +314,15 @@ func TestMakeAssetTransferTxn(t *testing.T) {
 	expectedAssetTransferTxn.AssetAmount = amountToSend
 
 	require.Equal(t, expectedAssetTransferTxn, tx)
+
+	// now compare tx against a golden
+	const addrSK = "awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred"
+	const signedGolden = "gqNzaWfEQGkk9CtvOKnn4nU59xmPGoZvYv+6TCu5B95PgwQ/YytwE9dr199ehEqAnSS0C2SaO4YhEBAk+JVOiwZiRq/w1gijdHhuiqRhYW10AaZhY2xvc2XEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pGFyY3bEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9o2ZlZc0MRKJmds4ABOwPomdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJsds4ABO/4o3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2kdHlwZaVheGZlcqR4YWlkgqFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFpAQ=="
+	private, err := mnemonic.ToPrivateKey(addrSK)
+	require.NoError(t, err)
+	_, newStxBytes, err := crypto.SignTransaction(private, tx)
+	require.NoError(t, err)
+	require.EqualValues(t, newStxBytes, byteFromBase64(signedGolden))
 }
 
 func TestMakeAssetAcceptanceTxn(t *testing.T) {

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -271,6 +271,11 @@ func TestMakeAssetTransferTxn(t *testing.T) {
 	require.True(t, false)
 }
 
+func TestMakeAssetAcceptanceTxn(t *testing.T) {
+	// TODO ejr always fail for now
+	require.True(t, false)
+}
+
 func TestComputeGroupID(t *testing.T) {
 	// compare regular transactions created in SDK with 'goal clerk send' result
 	// compare transaction group created in SDK with 'goal clerk group' result

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -267,8 +267,53 @@ func TestMakeAssetFreezeTxn(t *testing.T) {
 }
 
 func TestMakeAssetTransferTxn(t *testing.T) {
-	// TODO ejr always fail for now
-	require.True(t, false)
+	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
+	const genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+	const sender, recipient, creator, closeAssetsTo = addr, addr, addr, addr
+	const assetIndex = 1
+	const firstValidRound = 322575
+	const lastValidRound = 323575
+	const amountToSend = 1
+
+	tx, err := MakeAssetTransferTxn(sender, recipient, closeAssetsTo, amountToSend, 10, firstValidRound,
+		lastValidRound, nil, "", genesisHash, creator, assetIndex)
+	require.NoError(t, err)
+
+	sendAddr, err := types.DecodeAddress(sender)
+	require.NoError(t, err)
+
+	expectedAssetTransferTxn := types.Transaction{
+		Type: types.AssetTransferTx,
+		Header: types.Header{
+			Sender:      sendAddr,
+			Fee:         3140,
+			FirstValid:  firstValidRound,
+			LastValid:   lastValidRound,
+			GenesisHash: byte32ArrayFromBase64(genesisHash),
+			GenesisID:   "",
+		},
+	}
+
+	creatorAddr, err := types.DecodeAddress(creator)
+	require.NoError(t, err)
+
+	expectedAssetID := types.AssetID{
+		Creator: creatorAddr,
+		Index:   assetIndex,
+	}
+	expectedAssetTransferTxn.XferAsset = expectedAssetID
+
+	receiveAddr, err := types.DecodeAddress(recipient)
+	require.NoError(t, err)
+	expectedAssetTransferTxn.AssetReceiver = receiveAddr
+
+	closeAddr, err := types.DecodeAddress(closeAssetsTo)
+	require.NoError(t, err)
+	expectedAssetTransferTxn.AssetCloseTo = closeAddr
+
+	expectedAssetTransferTxn.AssetAmount = amountToSend
+
+	require.Equal(t, expectedAssetTransferTxn, tx)
 }
 
 func TestMakeAssetAcceptanceTxn(t *testing.T) {

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -267,6 +267,10 @@ func TestMakeAssetFreezeTxn(t *testing.T) {
 }
 
 func TestMakeAssetTransferTxn(t *testing.T) {
+	const addrSK = "awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred"
+	private, err := mnemonic.ToPrivateKey(addrSK)
+	require.NoError(t, err)
+
 	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
 	const genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
 	const sender, recipient, creator, closeAssetsTo = addr, addr, addr, addr
@@ -316,10 +320,7 @@ func TestMakeAssetTransferTxn(t *testing.T) {
 	require.Equal(t, expectedAssetTransferTxn, tx)
 
 	// now compare tx against a golden
-	const addrSK = "awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred"
 	const signedGolden = "gqNzaWfEQGkk9CtvOKnn4nU59xmPGoZvYv+6TCu5B95PgwQ/YytwE9dr199ehEqAnSS0C2SaO4YhEBAk+JVOiwZiRq/w1gijdHhuiqRhYW10AaZhY2xvc2XEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pGFyY3bEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9o2ZlZc0MRKJmds4ABOwPomdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJsds4ABO/4o3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2kdHlwZaVheGZlcqR4YWlkgqFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFpAQ=="
-	private, err := mnemonic.ToPrivateKey(addrSK)
-	require.NoError(t, err)
 	_, newStxBytes, err := crypto.SignTransaction(private, tx)
 	require.NoError(t, err)
 	require.EqualValues(t, newStxBytes, byteFromBase64(signedGolden))

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -266,6 +266,11 @@ func TestMakeAssetFreezeTxn(t *testing.T) {
 	require.Equal(t, expectedAssetFreezeTxn, tx)
 }
 
+func TestMakeAssetTransferTxn(t *testing.T) {
+	// TODO ejr always fail for now
+	require.True(t, false)
+}
+
 func TestComputeGroupID(t *testing.T) {
 	// compare regular transactions created in SDK with 'goal clerk send' result
 	// compare transaction group created in SDK with 'goal clerk group' result

--- a/types/basics.go
+++ b/types/basics.go
@@ -16,6 +16,8 @@ const (
 	KeyRegistrationTx TxType = "keyreg"
 	// AssetConfigTx creates, re-configures, or destroys an asset
 	AssetConfigTx TxType = "acfg"
+	// AssetTransferTx transfers assets between accounts (optionally closing)
+	AssetTransferTx TxType = "axfer"
 	// AssetFreezeTx changes the freeze status of an asset
 	AssetFreezeTx TxType = "afrz"
 )

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -14,6 +14,7 @@ type Transaction struct {
 	KeyregTxnFields
 	PaymentTxnFields
 	AssetConfigTxnFields
+	AssetTransferTxnFields
 	AssetFreezeTxnFields
 }
 


### PR DESCRIPTION
## Summary
This PR proposes to add asset transfer transactions.
Additionally, it proposes to add "I accept asset X" transactions, which are a special case of asset transfer transactions.
Additionally, it proposes to add revocation transactions, which are asset transfer transactions where the clawback address is revoking asset ownership from another account. 
Additionally, it proposes to add helpers for mint and burn asset transactions. N.B. these helpers do not query the asset's AssetParams to see if the `reserve` account passed to the helper actually map to the `reserve` account stored for the asset.

### Testing
Unit tests in `transaction_test.go` WIP