### PR TITLE
README update: add add go-generate to install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ To download the SDK, open a terminal and use the `go get` command.
 
 ```command
 go get -u github.com/algorand/go-algorand-sdk/...
+go generate github.com/algorand/go-algorand-sdk/...
 ```
 
 If you are connected to the Algorand network, your algod process should already be running. The kmd process must be started manually, however. Start and stop kmd using `goal kmd start` and `goal kmd stop`:


### PR DESCRIPTION
go-algorand-sdk now has TEAL lang spec that is generated from json
as part of build process. By design go-get does not run go-generate,
so that one need to run go-generate as part of installation