### PR TITLE
Update for new asset behavior (incl. README updates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,3 +773,147 @@ func main() {
 	}
 }
 ```
+
+## Assets
+
+The Algorand protocol allows users to create and trade named assets on layer one. Creating and managing these assets
+is done through the issuing of asset transactions. This section details how to make asset transactions, and what they do.
+
+Asset creation: This allows a user to issue a new asset. The user can define the number of assets in circulation,
+whether there is an account that can revoke assets, whether there is an account that can freeze user accounts, 
+whether there is an account that can be considered the asset reserve, and whether there is an account that can change
+the other accounts. The creating user can also do things like specify a name for the asset.
+                                                                        
+```golang
+addr := "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4" // the account issuing the transaction; the asset creator
+fee := uint64(10) // the number of microAlgos per byte to pay as a transaction fee
+defaultFrozen := false // whether user accounts will need to be unfrozen before transacting
+genesisHash := "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=" // hash of the genesis block of the network to be used
+totalIssuance := uint64(100) // total number of this asset in circulation
+reserve := addr // specified address is considered the asset reserve (it has no special privileges, this is only informational)
+freeze := addr // specified address can freeze or unfreeze user asset holdings
+clawback := addr // specified address can revoke user asset holdings and send them to other addresses
+manager := addr // specified address can change reserve, freeze, clawback, and manager
+unitName := "tst" // used to display asset units to user
+assetName := "testcoin" // "friendly name" of asset
+genesisID := "" // like genesisHash this is used to specify network to be used
+firstRound := uint64(322575) // first Algorand round on which this transaction is valid
+lastRound := uint64(322575) // last Algorand round on which this transaction is valid
+note := nil // arbitrary data to be stored in the transaction; here, none is stored
+assetURL := "http://someurl" // optional string pointing to a URL relating to the asset 
+assetMetadataHash := "thisIsSomeLength32HashCommitment" // optional hash commitment of some sort relating to the asset. 32 character length.
+
+// signing and sending "txn" allows "addr" to create an asset
+txn, err = MakeAssetCreateTxn(addr, fee, firstRound, lastRound, note,
+    genesisID, genesisHash, totalIssuance, defaultFrozen, manager, reserve, freeze, clawback,
+    unitName, assetName, assetURL, assetMetadataHash)
+```
+
+
+Asset reconfiguration: This allows the address specified as `manager` to change any of the special addresses for the asset,
+such as the reserve address. To keep an address the same, it must be re-specified in each new configuration transaction.
+Supplying an empty address is the same as turning the associated feature off for this asset. Once a special address
+is set to the empty address, it can never change again. For example, if an asset configuration transaction specifying
+`clawback=""` were issued, the associated asset could never be revoked from asset holders, and `clawback=""` would be
+true for all time.                 
+
+```golang
+addr := "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
+fee := uint64(10)
+firstRound := uint64(322575)
+lastRound := uint64(322575)
+note := nil
+genesisID := ""
+genesisHash := "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+assetIndex := uint64(1234)
+reserve := addr
+freeze := addr
+clawback := addr
+manager := addr
+
+// signing and sending "txn" will allow the asset manager to change:
+// asset manager, asset reserve, asset freeze manager, asset revocation manager 
+txn, err = MakeAssetConfigTxn(addr, fee, firstRound, lastRound, note,
+    genesisID, genesisHash, assetIndex, manager, reserve, freeze, clawback)
+```
+
+
+Asset destruction: This allows the creator to remove the asset from the ledger, if all outstanding assets are held
+by the creator.
+
+```golang
+addr := "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4" 
+fee := uint64(10)
+firstRound := uint64(322575) 
+lastRound := uint64(322575) 
+note := nil
+genesisID := ""
+genesisHash := "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+assetIndex := uint64(1234)
+
+// if all outstanding assets are held by the asset creator,
+// the asset creator can sign and issue "txn" to remove the asset from the ledger. 
+txn, err = MakeAssetDestroyTxn(addr, fee, firstRound, lastRound, note, genesisID, genesisHash, assetIndex)
+```
+
+Begin accepting an asset: Before a user can begin transacting with an asset, the user must first issue an asset acceptance transaction.
+This is a special case of the asset transfer transaction, where the user sends 0 assets to themself. After issuing this transaction,
+the user can begin transacting with the asset. Each new accepted asset increases the user's minimum balance.                                                                                                                               
+
+```golang
+addr := "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
+fee := uint64(10)
+firstRound := uint64(322575)
+lastRound := uint64(322575)
+note := nil
+genesisID := ""
+genesisHash := "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+assetIndex := uint64(1234)
+
+// signing and sending "txn" allows sender to begin accepting asset specified by creator and index
+txn, err = MakeAssetAcceptanceTxn(addr, fee, firstRound, lastRound, note, genesisID, genesisHash, assetIndex)
+```
+
+
+Transfer an asset: This allows users to transact with assets, after they have issued asset acceptance transactions. The
+optional `closeRemainderTo` argument can be used to stop transacting with a particular asset. Note: A frozen account can always close
+out to the asset creator.                                                                                                             
+```golang
+addr := "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4" 
+sender := addr
+recipient := "47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU"
+closeRemainderTo := "" // supply an address to close remaining balance after transfer to supplied address
+fee := uint64(10)
+firstRound := uint64(322575) 
+lastRound := uint64(322575) 
+note := nil
+genesisID := ""
+genesisHash := "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+assetIndex := uint64(1234)
+amount := uint64(10)
+
+// signing and sending "txn" will send "amount" assets from "sender" to "recipient"
+txn, err = MakeAssetTransferTxn(sender, recipient, closeRemainderTo, amount, fee, firstRound, lastRound, note,
+    genesisID, genesisHash, assetIndex);
+```
+
+Revoke an asset: This allows an asset's revocation manager to transfer assets on behalf of another user. It will only work when 
+issued by the asset's revocation manager.
+```golang
+revocationManager := "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4" // txn signed by this address
+recipient := "47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU"         // assets sent to this address
+revocationTarget := "47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU"  // assets come from this address
+fee := uint64(10)
+firstRound := uint64(322575) 
+lastRound := uint64(322575) 
+note := nil
+genesisID := ""
+genesisHash := "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+assetIndex := uint64(1234)
+amount := uint64(10)
+
+// signing and sending "txn" will send "amount" assets from "revocationTarget" to "recipient",
+// if and only if sender == clawback manager for this asset
+txn, err = MakeAssetRevocationTxn(revocationManager, recipient, revocationTarget, amount, fee, firstRound, lastRound, note,
+    genesisID, genesisHash, assetIndex);
+```

--- a/client/algod/models/models.go
+++ b/client/algod/models/models.go
@@ -145,6 +145,19 @@ type AssetParams struct {
 	// required: false
 	AssetName string `json:"assetname"`
 
+	// URL specifies a URL where more information about the asset can be
+	// retrieved
+	//
+	// required: false
+	URL string `json:"url"`
+
+	// MetadataHash specifies a commitment to some unspecified asset
+	// metadata. The format of this metadata is up to the application.
+	//
+	// required: false
+	// swagger:strfmt byte
+	MetadataHash []byte `json:"metadatahash"`
+
 	// ManagerAddr specifies the address used to manage the keys of this
 	// asset and to destroy it.
 	//

--- a/client/algod/wrappers.go
+++ b/client/algod/wrappers.go
@@ -91,8 +91,8 @@ func (client Client) AccountInformation(address string, headers ...*Header) (res
 }
 
 // AssetInformation also gets the AssetInformationResponse associated with the passed asset creator and index
-func (client Client) AssetInformation(creator string, index uint64, headers ...*Header) (response models.AssetParams, err error) {
-	err = client.get(&response, fmt.Sprintf("/account/%s/assets/%d", creator, index), nil, headers)
+func (client Client) AssetInformation(index uint64, headers ...*Header) (response models.AssetParams, err error) {
+	err = client.get(&response, fmt.Sprintf("/asset/%d", index), nil, headers)
 	return
 }
 

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -215,6 +215,9 @@ func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64
 	tx.AssetParams = types.AssetParams{
 		Total:         total,
 		DefaultFrozen: defaultFrozen,
+		UnitName:      unitName,
+		AssetName:     assetName,
+		URL:           url,
 	}
 
 	if manager != "" {
@@ -241,20 +244,6 @@ func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64
 			return tx, err
 		}
 	}
-	if len(unitName) > len(tx.AssetParams.UnitName) {
-		return tx, fmt.Errorf("asset unit name %s too long (max %d bytes)", unitName, len(tx.AssetParams.UnitName))
-	}
-	copy(tx.AssetParams.UnitName[:], []byte(unitName))
-
-	if len(assetName) > len(tx.AssetParams.AssetName) {
-		return tx, fmt.Errorf("asset name %s too long (max %d bytes)", assetName, len(tx.AssetParams.AssetName))
-	}
-	copy(tx.AssetParams.AssetName[:], []byte(assetName))
-
-	if len(url) > len(tx.AssetParams.URL) {
-		return tx, fmt.Errorf("asset url %s too long (max %d bytes)", url, len(tx.AssetParams.URL))
-	}
-	copy(tx.AssetParams.URL[:], []byte(url))
 
 	if len(metadataHash) > len(tx.AssetParams.MetadataHash) {
 		return tx, fmt.Errorf("asset name %s too long (max %d bytes)", metadataHash, len(tx.AssetParams.MetadataHash))

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -245,7 +245,22 @@ func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64
 		}
 	}
 
-	if len(metadataHash) > len(tx.AssetParams.MetadataHash) {
+	if len(assetName) > types.AssetNameMaxLen {
+		return tx, fmt.Errorf("asset name too long: %d > %d", len(assetName), types.AssetNameMaxLen)
+	}
+	tx.AssetParams.AssetName = assetName
+
+	if len(url) > types.AssetURLMaxLen {
+		return tx, fmt.Errorf("asset url too long: %d > %d", len(url), types.AssetURLMaxLen)
+	}
+	tx.AssetParams.URL = url
+
+	if len(unitName) > types.AssetUnitNameMaxLen {
+		return tx, fmt.Errorf("asset unit name too long: %d > %d", len(unitName), types.AssetUnitNameMaxLen)
+	}
+	tx.AssetParams.UnitName = unitName
+
+	if len(metadataHash) > types.AssetMetadataHashLen {
 		return tx, fmt.Errorf("asset metadata hash %s too long (max %d bytes)", metadataHash, len(tx.AssetParams.MetadataHash))
 	}
 	copy(tx.AssetParams.MetadataHash[:], []byte(metadataHash))

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -246,7 +246,7 @@ func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64
 	}
 
 	if len(metadataHash) > len(tx.AssetParams.MetadataHash) {
-		return tx, fmt.Errorf("asset name %s too long (max %d bytes)", metadataHash, len(tx.AssetParams.MetadataHash))
+		return tx, fmt.Errorf("asset metadata hash %s too long (max %d bytes)", metadataHash, len(tx.AssetParams.MetadataHash))
 	}
 	copy(tx.AssetParams.MetadataHash[:], []byte(metadataHash))
 

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -233,7 +233,7 @@ func TestMakeAssetDestroyTxn(t *testing.T) {
 		Type: types.AssetConfigTx,
 		Header: types.Header{
 			Sender:      a,
-			Fee:         1900,
+			Fee:         1880,
 			FirstValid:  firstValidRound,
 			LastValid:   lastValidRound,
 			GenesisHash: byte32ArrayFromBase64(genesisHash),
@@ -248,7 +248,7 @@ func TestMakeAssetDestroyTxn(t *testing.T) {
 	private, err := mnemonic.ToPrivateKey(addrSK)
 	require.NoError(t, err)
 	_, newStxBytes, err := crypto.SignTransaction(private, tx)
-	signedGolden := "gqNzaWfEQPd0mv/T/t92g08WiJ9f/l0QsiHhFu8D9hSYt5z7cExhSStmVN5WV9wHRUOyAy6SFC72OutIi58rNxOcc+ZmTASjdHhuh6RjYWlkAaNmZWXNB2yiZnbOAATsD6JnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAATv96NzbmTEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pHR5cGWkYWNmZw=="
+	signedGolden := "gqNzaWfEQBSP7HtzD/Lvn4aVvaNpeR4T93dQgo4LvywEwcZgDEoc/WVl3aKsZGcZkcRFoiWk8AidhfOZzZYutckkccB8RgGjdHhuh6RjYWlkAaNmZWXNB1iiZnbOAATsD6JnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAATv96NzbmTEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pHR5cGWkYWNmZw=="
 	require.EqualValues(t, newStxBytes, byteFromBase64(signedGolden))
 }
 
@@ -405,7 +405,7 @@ func TestMakeAssetRevocationTransaction(t *testing.T) {
 		Type: types.AssetTransferTx,
 		Header: types.Header{
 			Sender:      sendAddr,
-			Fee:         2750,
+			Fee:         2730,
 			FirstValid:  firstValidRound,
 			LastValid:   lastValidRound,
 			GenesisHash: byte32ArrayFromBase64(genesisHash),
@@ -432,7 +432,7 @@ func TestMakeAssetRevocationTransaction(t *testing.T) {
 	private, err := mnemonic.ToPrivateKey(addrSK)
 	require.NoError(t, err)
 	_, newStxBytes, err := crypto.SignTransaction(private, tx)
-	signedGolden := "gqNzaWfEQHIBdz/aZdjl3qE8j9IPedxw6HoFvI91fDwiMHNe+v6XDqRSm7BoFIUoRzSsaRXt3TCh4nEwhD/qxsXvYBbB+AGjdHhuiqRhYW10AaRhcmN2xCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aRhc25kxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aNmZWXNCr6iZnbOAATsD6JnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAATv96NzbmTEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pHR5cGWlYXhmZXKkeGFpZAE="
+	signedGolden := "gqNzaWfEQHsgfEAmEHUxLLLR9s+Y/yq5WeoGo/jAArCbany+7ZYwExMySzAhmV7M7S8+LBtJalB4EhzEUMKmt3kNKk6+vAWjdHhuiqRhYW10AaRhcmN2xCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aRhc25kxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aNmZWXNCqqiZnbOAATsD6JnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAATv96NzbmTEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pHR5cGWlYXhmZXKkeGFpZAE="
 	require.EqualValues(t, newStxBytes, byteFromBase64(signedGolden))
 }
 

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -176,7 +176,6 @@ func TestMakeAssetCreateTxn(t *testing.T) {
 func TestMakeAssetConfigTxn(t *testing.T) {
 	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
 	const genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
-	const creator = addr
 	const manager = addr
 	const reserve = addr
 	const freeze = addr
@@ -186,7 +185,7 @@ func TestMakeAssetConfigTxn(t *testing.T) {
 		assetIndex, manager, reserve, freeze, clawback)
 	require.NoError(t, err)
 
-	a, err := types.DecodeAddress(creator)
+	a, err := types.DecodeAddress(addr)
 	require.NoError(t, err)
 	expectedAssetConfigTxn := types.Transaction{
 		Type: types.AssetConfigTx,

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -133,7 +133,7 @@ func TestMakeAssetCreateTxn(t *testing.T) {
 	const unitName = "tst"
 	const assetName = "testcoin"
 	const testURL = "website"
-	const metadataHash = "somehash"
+	const metadataHash = "fACPO4nRgO55j1ndAK3W6Sgc4APkcyFh"
 	tx, err := MakeAssetCreateTxn(addr, 10, 322575, 323575, nil, "", genesisHash,
 		total, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName, testURL, metadataHash)
 	require.NoError(t, err)
@@ -144,7 +144,7 @@ func TestMakeAssetCreateTxn(t *testing.T) {
 		Type: types.AssetConfigTx,
 		Header: types.Header{
 			Sender:      a,
-			Fee:         4590,
+			Fee:         4020,
 			FirstValid:  322575,
 			LastValid:   323575,
 			GenesisHash: byte32ArrayFromBase64(genesisHash),
@@ -158,10 +158,10 @@ func TestMakeAssetCreateTxn(t *testing.T) {
 		Reserve:       a,
 		Freeze:        a,
 		Clawback:      a,
+		UnitName:      unitName,
+		AssetName:     assetName,
+		URL:           testURL,
 	}
-	copy(expectedAssetCreationTxn.AssetParams.UnitName[:], []byte(unitName))
-	copy(expectedAssetCreationTxn.AssetParams.AssetName[:], []byte(assetName))
-	copy(expectedAssetCreationTxn.AssetParams.URL[:], []byte(testURL))
 	copy(expectedAssetCreationTxn.AssetParams.MetadataHash[:], []byte(metadataHash))
 	require.Equal(t, expectedAssetCreationTxn, tx)
 
@@ -169,7 +169,7 @@ func TestMakeAssetCreateTxn(t *testing.T) {
 	private, err := mnemonic.ToPrivateKey(addrSK)
 	require.NoError(t, err)
 	_, newStxBytes, err := crypto.SignTransaction(private, tx)
-	signedGolden := "gqNzaWfEQGgrTyL9vDPnfdHhNycCFm+reimO11pXK0jNcvWigQ5iHUzg3OrY5QlNTUXRcCrLP07K256WPy+5aRtrYvwMgwWjdHhuh6RhcGFyiaJhbcQgc29tZWhhc2gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACiYW7EIHRlc3Rjb2luAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAomF1xCB3ZWJzaXRlAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFmxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFtxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFyxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aF0ZKJ1bsQIdHN0AAAAAACjZmVlzRHuomZ2zgAE7A+iZ2jEIEhjtRiks8hOyBDyLU8QgcsPcfBZp6wg3sYvf3DlCToiomx2zgAE7/ejc25kxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aR0eXBlpGFjZmc="
+	signedGolden := "gqNzaWfEQEDd1OMRoQI/rzNlU4iiF50XQXmup3k5czI9hEsNqHT7K4KsfmA/0DUVkbzOwtJdRsHS8trm3Arjpy9r7AXlbAujdHhuh6RhcGFyiaJhbcQgZkFDUE80blJnTzU1ajFuZEFLM1c2U2djNEFQa2N5RmiiYW6odGVzdGNvaW6iYXWnd2Vic2l0ZaFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFmxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFtxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFyxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aF0ZKJ1bqN0c3SjZmVlzQ+0omZ2zgAE7A+iZ2jEIEhjtRiks8hOyBDyLU8QgcsPcfBZp6wg3sYvf3DlCToiomx2zgAE7/ejc25kxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aR0eXBlpGFjZmc="
 	require.EqualValues(t, newStxBytes, byteFromBase64(signedGolden))
 }
 

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -132,8 +132,10 @@ func TestMakeAssetCreateTxn(t *testing.T) {
 	const clawback = addr
 	const unitName = "tst"
 	const assetName = "testcoin"
+	const testURL = "website"
+	const metadataHash = "somehash"
 	tx, err := MakeAssetCreateTxn(addr, 10, 322575, 323575, nil, "", genesisHash,
-		total, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName)
+		total, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName, testURL, metadataHash)
 	require.NoError(t, err)
 
 	a, err := types.DecodeAddress(addr)
@@ -142,7 +144,7 @@ func TestMakeAssetCreateTxn(t *testing.T) {
 		Type: types.AssetConfigTx,
 		Header: types.Header{
 			Sender:      a,
-			Fee:         3850,
+			Fee:         4590,
 			FirstValid:  322575,
 			LastValid:   323575,
 			GenesisHash: byte32ArrayFromBase64(genesisHash),
@@ -159,6 +161,8 @@ func TestMakeAssetCreateTxn(t *testing.T) {
 	}
 	copy(expectedAssetCreationTxn.AssetParams.UnitName[:], []byte(unitName))
 	copy(expectedAssetCreationTxn.AssetParams.AssetName[:], []byte(assetName))
+	copy(expectedAssetCreationTxn.AssetParams.URL[:], []byte(testURL))
+	copy(expectedAssetCreationTxn.AssetParams.MetadataHash[:], []byte(metadataHash))
 	require.Equal(t, expectedAssetCreationTxn, tx)
 }
 
@@ -170,8 +174,9 @@ func TestMakeAssetConfigTxn(t *testing.T) {
 	const reserve = addr
 	const freeze = addr
 	const clawback = addr
+	const assetIndex = 1234
 	tx, err := MakeAssetConfigTxn(addr, 10, 322575, 323575, nil, "", genesisHash,
-		creator, 1234, manager, reserve, freeze, clawback)
+		assetIndex, manager, reserve, freeze, clawback)
 	require.NoError(t, err)
 
 	a, err := types.DecodeAddress(creator)
@@ -180,7 +185,7 @@ func TestMakeAssetConfigTxn(t *testing.T) {
 		Type: types.AssetConfigTx,
 		Header: types.Header{
 			Sender:      a,
-			Fee:         3790,
+			Fee:         3400,
 			FirstValid:  322575,
 			LastValid:   323575,
 			GenesisHash: byte32ArrayFromBase64(genesisHash),
@@ -194,10 +199,7 @@ func TestMakeAssetConfigTxn(t *testing.T) {
 		Freeze:   a,
 		Clawback: a,
 	}
-	expectedAssetConfigTxn.ConfigAsset = types.AssetID{
-		Creator: a,
-		Index:   1234,
-	}
+	expectedAssetConfigTxn.ConfigAsset = types.AssetIndex(assetIndex)
 	require.Equal(t, expectedAssetConfigTxn, tx)
 }
 
@@ -208,7 +210,7 @@ func TestMakeAssetDestroyTxn(t *testing.T) {
 	const assetIndex = 1
 	const firstValidRound = 322575
 	const lastValidRound = 323575
-	tx, err := MakeAssetDestroyTxn(creator, 10, firstValidRound, lastValidRound, nil, "", genesisHash, creator, assetIndex)
+	tx, err := MakeAssetDestroyTxn(creator, 10, firstValidRound, lastValidRound, nil, "", genesisHash, assetIndex)
 	require.NoError(t, err)
 
 	a, err := types.DecodeAddress(creator)
@@ -218,7 +220,7 @@ func TestMakeAssetDestroyTxn(t *testing.T) {
 		Type: types.AssetConfigTx,
 		Header: types.Header{
 			Sender:      a,
-			Fee:         2290,
+			Fee:         1900,
 			FirstValid:  firstValidRound,
 			LastValid:   lastValidRound,
 			GenesisHash: byte32ArrayFromBase64(genesisHash),
@@ -226,41 +228,36 @@ func TestMakeAssetDestroyTxn(t *testing.T) {
 		},
 	}
 	expectedAssetConfigTxn.AssetParams = types.AssetParams{}
-	expectedAssetConfigTxn.ConfigAsset = types.AssetID{
-		Creator: a,
-		Index:   assetIndex,
-	}
+	expectedAssetConfigTxn.ConfigAsset = types.AssetIndex(assetIndex)
 	require.Equal(t, expectedAssetConfigTxn, tx)
 }
 
 func TestMakeAssetFreezeTxn(t *testing.T) {
 	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
 	const genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
-	const creator = addr
 	const assetIndex = 1
 	const firstValidRound = 322575
 	const lastValidRound = 323576
 	const freezeSetting = true
-	const target = creator
-	tx, err := MakeAssetFreezeTxn(creator, 10, firstValidRound, lastValidRound, nil, "", genesisHash, creator, assetIndex, target, freezeSetting)
+	const target = addr
+	tx, err := MakeAssetFreezeTxn(addr, 10, firstValidRound, lastValidRound, nil, "", genesisHash, assetIndex, target, freezeSetting)
 	require.NoError(t, err)
 
-	a, err := types.DecodeAddress(creator)
+	a, err := types.DecodeAddress(addr)
 	require.NoError(t, err)
 
 	expectedAssetFreezeTxn := types.Transaction{
 		Type: types.AssetFreezeTx,
 		Header: types.Header{
 			Sender:      a,
-			Fee:         2720,
+			Fee:         2330,
 			FirstValid:  firstValidRound,
 			LastValid:   lastValidRound,
 			GenesisHash: byte32ArrayFromBase64(genesisHash),
 			GenesisID:   "",
 		},
 	}
-	expectedAssetFreezeTxn.FreezeAsset.Creator = a
-	expectedAssetFreezeTxn.FreezeAsset.Index = assetIndex
+	expectedAssetFreezeTxn.FreezeAsset = types.AssetIndex(assetIndex)
 	expectedAssetFreezeTxn.AssetFrozen = freezeSetting
 	expectedAssetFreezeTxn.FreezeAccount = a
 	require.Equal(t, expectedAssetFreezeTxn, tx)
@@ -269,7 +266,7 @@ func TestMakeAssetFreezeTxn(t *testing.T) {
 	private, err := mnemonic.ToPrivateKey(addrSK)
 	require.NoError(t, err)
 	_, newStxBytes, err := crypto.SignTransaction(private, tx)
-	signedGolden := "gqNzaWfEQJsNp4Hm5qYBN1Foa8nGd3zeMFxGFJiAxuf3/L1A4MTgR521fId0nIYtMwbJha5zRpN/0UuNoq91IkOK7LVhzACjdHhuiaRhZnJ6w6RmYWRkxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aRmYWlkgqFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFpAaNmZWXNCqCiZnbOAATsD6JnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAATv+KNzbmTEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pHR5cGWkYWZyeg=="
+	signedGolden := "gqNzaWfEQAhru5V2Xvr19s4pGnI0aslqwY4lA2skzpYtDTAN9DKSH5+qsfQQhm4oq+9VHVj7e1rQC49S28vQZmzDTVnYDQGjdHhuiaRhZnJ6w6RmYWRkxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aRmYWlkAaNmZWXNCRqiZnbOAATsD6JnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAATv+KNzbmTEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pHR5cGWkYWZyeg=="
 	require.EqualValues(t, newStxBytes, byteFromBase64(signedGolden))
 }
 
@@ -280,14 +277,14 @@ func TestMakeAssetTransferTxn(t *testing.T) {
 
 	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
 	const genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
-	const sender, recipient, creator, closeAssetsTo = addr, addr, addr, addr
+	const sender, recipient, closeAssetsTo = addr, addr, addr
 	const assetIndex = 1
 	const firstValidRound = 322575
 	const lastValidRound = 323576
 	const amountToSend = 1
 
 	tx, err := MakeAssetTransferTxn(sender, recipient, closeAssetsTo, amountToSend, 10, firstValidRound,
-		lastValidRound, nil, "", genesisHash, creator, assetIndex)
+		lastValidRound, nil, "", genesisHash, assetIndex)
 	require.NoError(t, err)
 
 	sendAddr, err := types.DecodeAddress(sender)
@@ -297,7 +294,7 @@ func TestMakeAssetTransferTxn(t *testing.T) {
 		Type: types.AssetTransferTx,
 		Header: types.Header{
 			Sender:      sendAddr,
-			Fee:         3140,
+			Fee:         2750,
 			FirstValid:  firstValidRound,
 			LastValid:   lastValidRound,
 			GenesisHash: byte32ArrayFromBase64(genesisHash),
@@ -305,13 +302,7 @@ func TestMakeAssetTransferTxn(t *testing.T) {
 		},
 	}
 
-	creatorAddr, err := types.DecodeAddress(creator)
-	require.NoError(t, err)
-
-	expectedAssetID := types.AssetID{
-		Creator: creatorAddr,
-		Index:   assetIndex,
-	}
+	expectedAssetID := types.AssetIndex(assetIndex)
 	expectedAssetTransferTxn.XferAsset = expectedAssetID
 
 	receiveAddr, err := types.DecodeAddress(recipient)
@@ -327,23 +318,21 @@ func TestMakeAssetTransferTxn(t *testing.T) {
 	require.Equal(t, expectedAssetTransferTxn, tx)
 
 	// now compare tx against a golden
-	const signedGolden = "gqNzaWfEQGkk9CtvOKnn4nU59xmPGoZvYv+6TCu5B95PgwQ/YytwE9dr199ehEqAnSS0C2SaO4YhEBAk+JVOiwZiRq/w1gijdHhuiqRhYW10AaZhY2xvc2XEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pGFyY3bEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9o2ZlZc0MRKJmds4ABOwPomdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJsds4ABO/4o3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2kdHlwZaVheGZlcqR4YWlkgqFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFpAQ=="
+	const signedGolden = "gqNzaWfEQNkEs3WdfFq6IQKJdF1n0/hbV9waLsvojy9pM1T4fvwfMNdjGQDy+LeesuQUfQVTneJD4VfMP7zKx4OUlItbrwSjdHhuiqRhYW10AaZhY2xvc2XEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pGFyY3bEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9o2ZlZc0KvqJmds4ABOwPomdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJsds4ABO/4o3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2kdHlwZaVheGZlcqR4YWlkAQ=="
 	_, newStxBytes, err := crypto.SignTransaction(private, tx)
 	require.NoError(t, err)
 	require.EqualValues(t, newStxBytes, byteFromBase64(signedGolden))
 }
 
 func TestMakeAssetAcceptanceTxn(t *testing.T) {
-	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
+	const sender = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
 	const genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
-	const sender, creator = addr, addr
 	const assetIndex = 1
 	const firstValidRound = 322575
 	const lastValidRound = 323575
-	const amountToSend = 1
 
 	tx, err := MakeAssetAcceptanceTxn(sender, 10, firstValidRound,
-		lastValidRound, nil, "", genesisHash, creator, assetIndex)
+		lastValidRound, nil, "", genesisHash, assetIndex)
 	require.NoError(t, err)
 
 	sendAddr, err := types.DecodeAddress(sender)
@@ -353,7 +342,7 @@ func TestMakeAssetAcceptanceTxn(t *testing.T) {
 		Type: types.AssetTransferTx,
 		Header: types.Header{
 			Sender:      sendAddr,
-			Fee:         2670,
+			Fee:         2280,
 			FirstValid:  firstValidRound,
 			LastValid:   lastValidRound,
 			GenesisHash: byte32ArrayFromBase64(genesisHash),
@@ -361,13 +350,7 @@ func TestMakeAssetAcceptanceTxn(t *testing.T) {
 		},
 	}
 
-	creatorAddr, err := types.DecodeAddress(creator)
-	require.NoError(t, err)
-
-	expectedAssetID := types.AssetID{
-		Creator: creatorAddr,
-		Index:   assetIndex,
-	}
+	expectedAssetID := types.AssetIndex(assetIndex)
 	expectedAssetAcceptanceTxn.XferAsset = expectedAssetID
 	expectedAssetAcceptanceTxn.AssetReceiver = sendAddr
 	expectedAssetAcceptanceTxn.AssetAmount = 0
@@ -378,14 +361,14 @@ func TestMakeAssetAcceptanceTxn(t *testing.T) {
 func TestMakeAssetRevocationTransaction(t *testing.T) {
 	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
 	const genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
-	const revoker, recipient, revoked, creator = addr, addr, addr, addr
+	const revoker, recipient, revoked = addr, addr, addr
 	const assetIndex = 1
 	const firstValidRound = 322575
 	const lastValidRound = 323575
 	const amountToSend = 1
 
 	tx, err := MakeAssetRevocationTxn(revoker, revoked, recipient, amountToSend, 10, firstValidRound,
-		lastValidRound, nil, "", genesisHash, creator, assetIndex)
+		lastValidRound, nil, "", genesisHash, assetIndex)
 	require.NoError(t, err)
 
 	sendAddr, err := types.DecodeAddress(revoker)
@@ -395,7 +378,7 @@ func TestMakeAssetRevocationTransaction(t *testing.T) {
 		Type: types.AssetTransferTx,
 		Header: types.Header{
 			Sender:      sendAddr,
-			Fee:         3140,
+			Fee:         2750,
 			FirstValid:  firstValidRound,
 			LastValid:   lastValidRound,
 			GenesisHash: byte32ArrayFromBase64(genesisHash),
@@ -403,13 +386,7 @@ func TestMakeAssetRevocationTransaction(t *testing.T) {
 		},
 	}
 
-	creatorAddr, err := types.DecodeAddress(creator)
-	require.NoError(t, err)
-
-	expectedAssetID := types.AssetID{
-		Creator: creatorAddr,
-		Index:   assetIndex,
-	}
+	expectedAssetID := types.AssetIndex(assetIndex)
 	expectedAssetRevocationTxn.XferAsset = expectedAssetID
 
 	receiveAddr, err := types.DecodeAddress(recipient)

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -164,6 +164,13 @@ func TestMakeAssetCreateTxn(t *testing.T) {
 	copy(expectedAssetCreationTxn.AssetParams.URL[:], []byte(testURL))
 	copy(expectedAssetCreationTxn.AssetParams.MetadataHash[:], []byte(metadataHash))
 	require.Equal(t, expectedAssetCreationTxn, tx)
+
+	const addrSK = "awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred"
+	private, err := mnemonic.ToPrivateKey(addrSK)
+	require.NoError(t, err)
+	_, newStxBytes, err := crypto.SignTransaction(private, tx)
+	signedGolden := "gqNzaWfEQGgrTyL9vDPnfdHhNycCFm+reimO11pXK0jNcvWigQ5iHUzg3OrY5QlNTUXRcCrLP07K256WPy+5aRtrYvwMgwWjdHhuh6RhcGFyiaJhbcQgc29tZWhhc2gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACiYW7EIHRlc3Rjb2luAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAomF1xCB3ZWJzaXRlAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFmxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFtxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFyxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aF0ZKJ1bsQIdHN0AAAAAACjZmVlzRHuomZ2zgAE7A+iZ2jEIEhjtRiks8hOyBDyLU8QgcsPcfBZp6wg3sYvf3DlCToiomx2zgAE7/ejc25kxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aR0eXBlpGFjZmc="
+	require.EqualValues(t, newStxBytes, byteFromBase64(signedGolden))
 }
 
 func TestMakeAssetConfigTxn(t *testing.T) {
@@ -201,6 +208,13 @@ func TestMakeAssetConfigTxn(t *testing.T) {
 	}
 	expectedAssetConfigTxn.ConfigAsset = types.AssetIndex(assetIndex)
 	require.Equal(t, expectedAssetConfigTxn, tx)
+
+	const addrSK = "awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred"
+	private, err := mnemonic.ToPrivateKey(addrSK)
+	require.NoError(t, err)
+	_, newStxBytes, err := crypto.SignTransaction(private, tx)
+	signedGolden := "gqNzaWfEQBBkfw5n6UevuIMDo2lHyU4dS80JCCQ/vTRUcTx5m0ivX68zTKyuVRrHaTbxbRRc3YpJ4zeVEnC9Fiw3Wf4REwejdHhuiKRhcGFyhKFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFmxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFtxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFyxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aRjYWlkzQTSo2ZlZc0NSKJmds4ABOwPomdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJsds4ABO/3o3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2kdHlwZaRhY2Zn"
+	require.EqualValues(t, newStxBytes, byteFromBase64(signedGolden))
 }
 
 func TestMakeAssetDestroyTxn(t *testing.T) {
@@ -216,7 +230,7 @@ func TestMakeAssetDestroyTxn(t *testing.T) {
 	a, err := types.DecodeAddress(creator)
 	require.NoError(t, err)
 
-	expectedAssetConfigTxn := types.Transaction{
+	expectedAssetDestroyTxn := types.Transaction{
 		Type: types.AssetConfigTx,
 		Header: types.Header{
 			Sender:      a,
@@ -227,9 +241,16 @@ func TestMakeAssetDestroyTxn(t *testing.T) {
 			GenesisID:   "",
 		},
 	}
-	expectedAssetConfigTxn.AssetParams = types.AssetParams{}
-	expectedAssetConfigTxn.ConfigAsset = types.AssetIndex(assetIndex)
-	require.Equal(t, expectedAssetConfigTxn, tx)
+	expectedAssetDestroyTxn.AssetParams = types.AssetParams{}
+	expectedAssetDestroyTxn.ConfigAsset = types.AssetIndex(assetIndex)
+	require.Equal(t, expectedAssetDestroyTxn, tx)
+
+	const addrSK = "awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred"
+	private, err := mnemonic.ToPrivateKey(addrSK)
+	require.NoError(t, err)
+	_, newStxBytes, err := crypto.SignTransaction(private, tx)
+	signedGolden := "gqNzaWfEQPd0mv/T/t92g08WiJ9f/l0QsiHhFu8D9hSYt5z7cExhSStmVN5WV9wHRUOyAy6SFC72OutIi58rNxOcc+ZmTASjdHhuh6RjYWlkAaNmZWXNB2yiZnbOAATsD6JnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAATv96NzbmTEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pHR5cGWkYWNmZw=="
+	require.EqualValues(t, newStxBytes, byteFromBase64(signedGolden))
 }
 
 func TestMakeAssetFreezeTxn(t *testing.T) {
@@ -356,6 +377,13 @@ func TestMakeAssetAcceptanceTxn(t *testing.T) {
 	expectedAssetAcceptanceTxn.AssetAmount = 0
 
 	require.Equal(t, expectedAssetAcceptanceTxn, tx)
+
+	const addrSK = "awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred"
+	private, err := mnemonic.ToPrivateKey(addrSK)
+	require.NoError(t, err)
+	_, newStxBytes, err := crypto.SignTransaction(private, tx)
+	signedGolden := "gqNzaWfEQJ7q2rOT8Sb/wB0F87ld+1zMprxVlYqbUbe+oz0WM63FctIi+K9eYFSqT26XBZ4Rr3+VTJpBE+JLKs8nctl9hgijdHhuiKRhcmN2xCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aNmZWXNCOiiZnbOAATsD6JnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAATv96NzbmTEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pHR5cGWlYXhmZXKkeGFpZAE="
+	require.EqualValues(t, newStxBytes, byteFromBase64(signedGolden))
 }
 
 func TestMakeAssetRevocationTransaction(t *testing.T) {
@@ -400,6 +428,13 @@ func TestMakeAssetRevocationTransaction(t *testing.T) {
 	expectedAssetRevocationTxn.AssetSender = targetAddr
 
 	require.Equal(t, expectedAssetRevocationTxn, tx)
+
+	const addrSK = "awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred"
+	private, err := mnemonic.ToPrivateKey(addrSK)
+	require.NoError(t, err)
+	_, newStxBytes, err := crypto.SignTransaction(private, tx)
+	signedGolden := "gqNzaWfEQHIBdz/aZdjl3qE8j9IPedxw6HoFvI91fDwiMHNe+v6XDqRSm7BoFIUoRzSsaRXt3TCh4nEwhD/qxsXvYBbB+AGjdHhuiqRhYW10AaRhcmN2xCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aRhc25kxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aNmZWXNCr6iZnbOAATsD6JnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAATv96NzbmTEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pHR5cGWlYXhmZXKkeGFpZAE="
+	require.EqualValues(t, newStxBytes, byteFromBase64(signedGolden))
 }
 
 func TestComputeGroupID(t *testing.T) {

--- a/types/asset.go
+++ b/types/asset.go
@@ -1,6 +1,16 @@
 package types
 
-const assetMetadataHashLen = 32
+// AssetNameMaxLen is the max length in bytes for the asset name
+const AssetNameMaxLen = 32
+
+// AssetUnitNameMaxLen is the max length in bytes for the asset unit name
+const AssetUnitNameMaxLen = 8
+
+// AssetURLMaxLen is the max length in bytes for the asset url
+const AssetURLMaxLen = 32
+
+// AssetMetadataHashLen is the length of the AssetMetadataHash in bytes
+const AssetMetadataHashLen = 32
 
 // AssetIndex is the unique integer index of an asset that can be used to look
 // up the creator of the asset, whose balance record contains the AssetParams
@@ -31,7 +41,7 @@ type AssetParams struct {
 
 	// MetadataHash specifies a commitment to some unspecified asset
 	// metadata. The format of this metadata is up to the application.
-	MetadataHash [assetMetadataHashLen]byte `codec:"am"`
+	MetadataHash [AssetMetadataHashLen]byte `codec:"am"`
 
 	// Manager specifies an account that is allowed to change the
 	// non-zero addresses in this AssetParams.

--- a/types/asset.go
+++ b/types/asset.go
@@ -1,8 +1,5 @@
 package types
 
-const assetUnitNameLen = 8
-const assetNameLen = 32
-const assetURLLen = 32
 const assetMetadataHashLen = 32
 
 // AssetIndex is the unique integer index of an asset that can be used to look
@@ -23,14 +20,14 @@ type AssetParams struct {
 
 	// UnitName specifies a hint for the name of a unit of
 	// this asset.
-	UnitName [assetUnitNameLen]byte `codec:"un"`
+	UnitName string `codec:"un"`
 
 	// AssetName specifies a hint for the name of the asset.
-	AssetName [assetNameLen]byte `codec:"an"`
+	AssetName string `codec:"an"`
 
 	// URL specifies a URL where more information about the asset can be
 	// retrieved
-	URL [assetURLLen]byte `codec:"au"`
+	URL string `codec:"au"`
 
 	// MetadataHash specifies a commitment to some unspecified asset
 	// metadata. The format of this metadata is up to the application.

--- a/types/asset.go
+++ b/types/asset.go
@@ -2,14 +2,12 @@ package types
 
 const assetUnitNameLen = 8
 const assetNameLen = 32
+const assetURLLen = 32
+const assetMetadataHashLen = 32
 
-// AssetID is a name of an asset.
-type AssetID struct {
-	_struct struct{} `codec:",omitempty,omitemptyarray"`
-
-	Creator Address `codec:"c"`
-	Index   uint64  `codec:"i"`
-}
+// AssetIndex is the unique integer index of an asset that can be used to look
+// up the creator of the asset, whose balance record contains the AssetParams
+type AssetIndex uint64
 
 // AssetParams describes the parameters of an asset.
 type AssetParams struct {
@@ -29,6 +27,14 @@ type AssetParams struct {
 
 	// AssetName specifies a hint for the name of the asset.
 	AssetName [assetNameLen]byte `codec:"an"`
+
+	// URL specifies a URL where more information about the asset can be
+	// retrieved
+	URL [assetURLLen]byte `codec:"au"`
+
+	// MetadataHash specifies a commitment to some unspecified asset
+	// metadata. The format of this metadata is up to the application.
+	MetadataHash [assetMetadataHashLen]byte `codec:"am"`
 
 	// Manager specifies an account that is allowed to change the
 	// non-zero addresses in this AssetParams.

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -60,8 +60,8 @@ type AssetConfigTxnFields struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
 	// ConfigAsset is the asset being configured or destroyed.
-	// A zero value (including the creator address) means allocation.
-	ConfigAsset AssetID `codec:"caid"`
+	// A zero value means allocation.
+	ConfigAsset AssetIndex `codec:"caid"`
 
 	// AssetParams are the parameters for the asset being
 	// created or re-configured.  A zero value means destruction.
@@ -72,7 +72,7 @@ type AssetConfigTxnFields struct {
 type AssetTransferTxnFields struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	XferAsset AssetID `codec:"xaid"`
+	XferAsset AssetIndex `codec:"xaid"`
 
 	// AssetAmount is the amount of asset to transfer.
 	// A zero amount transferred to self allocates that asset
@@ -91,7 +91,7 @@ type AssetTransferTxnFields struct {
 	// AssetCloseTo indicates that the asset should be removed
 	// from the account's Assets map, and specifies where the remaining
 	// asset holdings should be transferred.  It's always valid to transfer
-	// remaining asset holdings to the AssetID account.
+	// remaining asset holdings to the creator account.
 	AssetCloseTo Address `codec:"aclose"`
 }
 
@@ -104,7 +104,7 @@ type AssetFreezeTxnFields struct {
 	FreezeAccount Address `codec:"fadd"`
 
 	// FreezeAsset is the asset ID being frozen or un-frozen.
-	FreezeAsset AssetID `codec:"faid"`
+	FreezeAsset AssetIndex `codec:"faid"`
 
 	// AssetFrozen is the new frozen value.
 	AssetFrozen bool `codec:"afrz"`


### PR DESCRIPTION
## Summary
recent changes in `go-algorand` did things like: add support for `URL`s and `MetadataHash`es to assets. Also, the `creator` is no longer needed to index into assets. This PR proposes to update the `go` lang SDK to support these changes.
The `README.md` is also updated to discuss Assets.

### Testing
Unit tests updated.

###  See also
https://github.com/algorand/go-algorand-sdk/issues/63
https://github.com/algorand/go-algorand-sdk/issues/64
https://github.com/algorand/go-algorand-sdk/issues/67