### PR TITLE
Fix inconsistent genesis hash formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,7 +788,7 @@ the other accounts. The creating user can also do things like specify a name for
 addr := "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4" // the account issuing the transaction; the asset creator
 fee := uint64(10) // the number of microAlgos per byte to pay as a transaction fee
 defaultFrozen := false // whether user accounts will need to be unfrozen before transacting
-genesisHash := "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=" // hash of the genesis block of the network to be used
+genesisHash, _ := base64.StdEncoding.DecodeString("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=") // hash of the genesis block of the network to be used
 totalIssuance := uint64(100) // total number of this asset in circulation
 reserve := addr // specified address is considered the asset reserve (it has no special privileges, this is only informational)
 freeze := addr // specified address can freeze or unfreeze user asset holdings
@@ -824,7 +824,7 @@ firstRound := uint64(322575)
 lastRound := uint64(322575)
 note := nil
 genesisID := ""
-genesisHash := "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+genesisHash, _ := base64.StdEncoding.DecodeString("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=")
 assetIndex := uint64(1234)
 reserve := addr
 freeze := addr
@@ -848,7 +848,7 @@ firstRound := uint64(322575)
 lastRound := uint64(322575) 
 note := nil
 genesisID := ""
-genesisHash := "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+genesisHash, _ := base64.StdEncoding.DecodeString("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=")
 assetIndex := uint64(1234)
 
 // if all outstanding assets are held by the asset creator,
@@ -867,7 +867,7 @@ firstRound := uint64(322575)
 lastRound := uint64(322575)
 note := nil
 genesisID := ""
-genesisHash := "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+genesisHash, _ := base64.StdEncoding.DecodeString("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=")
 assetIndex := uint64(1234)
 
 // signing and sending "txn" allows sender to begin accepting asset specified by creator and index
@@ -888,7 +888,7 @@ firstRound := uint64(322575)
 lastRound := uint64(322575) 
 note := nil
 genesisID := ""
-genesisHash := "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+genesisHash, _ := base64.StdEncoding.DecodeString("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=")
 assetIndex := uint64(1234)
 amount := uint64(10)
 
@@ -908,7 +908,7 @@ firstRound := uint64(322575)
 lastRound := uint64(322575) 
 note := nil
 genesisID := ""
-genesisHash := "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+genesisHash, _ := base64.StdEncoding.DecodeString("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=")
 assetIndex := uint64(1234)
 amount := uint64(10)
 

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -94,7 +94,9 @@ func TestKeyRegTxn(t *testing.T) {
 
 func TestMakeKeyRegTxn(t *testing.T) {
 	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
-	tx, err := MakeKeyRegTxn(addr, 10, 322575, 323575, []byte{45, 67}, "", "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+	const genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+	ghBytes := byteFromBase64(genesisHash)
+	tx, err := MakeKeyRegTxn(addr, 10, 322575, 323575, []byte{45, 67}, "", ghBytes,
 		"Kv7QI7chi1y6axoy+t7wzAVpePqRq/rkjzWh/RMYyLo=", "bPgrv4YogPcdaUAxrt1QysYZTVyRAuUMD4zQmCu9llc=", 10000, 10111, 11)
 	require.NoError(t, err)
 
@@ -134,7 +136,8 @@ func TestMakeAssetCreateTxn(t *testing.T) {
 	const assetName = "testcoin"
 	const testURL = "website"
 	const metadataHash = "fACPO4nRgO55j1ndAK3W6Sgc4APkcyFh"
-	tx, err := MakeAssetCreateTxn(addr, 10, 322575, 323575, nil, "", genesisHash,
+	ghBytes := byteFromBase64(genesisHash)
+	tx, err := MakeAssetCreateTxn(addr, 10, 322575, 323575, nil, "", ghBytes,
 		total, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName, testURL, metadataHash)
 	require.NoError(t, err)
 
@@ -176,12 +179,13 @@ func TestMakeAssetCreateTxn(t *testing.T) {
 func TestMakeAssetConfigTxn(t *testing.T) {
 	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
 	const genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+	ghBytes := byteFromBase64(genesisHash)
 	const manager = addr
 	const reserve = addr
 	const freeze = addr
 	const clawback = addr
 	const assetIndex = 1234
-	tx, err := MakeAssetConfigTxn(addr, 10, 322575, 323575, nil, "", genesisHash,
+	tx, err := MakeAssetConfigTxn(addr, 10, 322575, 323575, nil, "", ghBytes,
 		assetIndex, manager, reserve, freeze, clawback)
 	require.NoError(t, err)
 
@@ -223,7 +227,8 @@ func TestMakeAssetDestroyTxn(t *testing.T) {
 	const assetIndex = 1
 	const firstValidRound = 322575
 	const lastValidRound = 323575
-	tx, err := MakeAssetDestroyTxn(creator, 10, firstValidRound, lastValidRound, nil, "", genesisHash, assetIndex)
+	ghBytes := byteFromBase64(genesisHash)
+	tx, err := MakeAssetDestroyTxn(creator, 10, firstValidRound, lastValidRound, nil, "", ghBytes, assetIndex)
 	require.NoError(t, err)
 
 	a, err := types.DecodeAddress(creator)
@@ -260,7 +265,8 @@ func TestMakeAssetFreezeTxn(t *testing.T) {
 	const lastValidRound = 323576
 	const freezeSetting = true
 	const target = addr
-	tx, err := MakeAssetFreezeTxn(addr, 10, firstValidRound, lastValidRound, nil, "", genesisHash, assetIndex, target, freezeSetting)
+	ghBytes := byteFromBase64(genesisHash)
+	tx, err := MakeAssetFreezeTxn(addr, 10, firstValidRound, lastValidRound, nil, "", ghBytes, assetIndex, target, freezeSetting)
 	require.NoError(t, err)
 
 	a, err := types.DecodeAddress(addr)
@@ -302,9 +308,9 @@ func TestMakeAssetTransferTxn(t *testing.T) {
 	const firstValidRound = 322575
 	const lastValidRound = 323576
 	const amountToSend = 1
-
+	ghBytes := byteFromBase64(genesisHash)
 	tx, err := MakeAssetTransferTxn(sender, recipient, closeAssetsTo, amountToSend, 10, firstValidRound,
-		lastValidRound, nil, "", genesisHash, assetIndex)
+		lastValidRound, nil, "", ghBytes, assetIndex)
 	require.NoError(t, err)
 
 	sendAddr, err := types.DecodeAddress(sender)
@@ -350,9 +356,9 @@ func TestMakeAssetAcceptanceTxn(t *testing.T) {
 	const assetIndex = 1
 	const firstValidRound = 322575
 	const lastValidRound = 323575
-
+	ghBytes := byteFromBase64(genesisHash)
 	tx, err := MakeAssetAcceptanceTxn(sender, 10, firstValidRound,
-		lastValidRound, nil, "", genesisHash, assetIndex)
+		lastValidRound, nil, "", ghBytes, assetIndex)
 	require.NoError(t, err)
 
 	sendAddr, err := types.DecodeAddress(sender)
@@ -393,9 +399,9 @@ func TestMakeAssetRevocationTransaction(t *testing.T) {
 	const firstValidRound = 322575
 	const lastValidRound = 323575
 	const amountToSend = 1
-
+	ghBytes := byteFromBase64(genesisHash)
 	tx, err := MakeAssetRevocationTxn(revoker, revoked, recipient, amountToSend, 10, firstValidRound,
-		lastValidRound, nil, "", genesisHash, assetIndex)
+		lastValidRound, nil, "", ghBytes, assetIndex)
 	require.NoError(t, err)
 
 	sendAddr, err := types.DecodeAddress(revoker)


### PR DESCRIPTION
This is backwards incompatible, so it will fail testing repo tests.
#76 and #39 