### PR TITLE
Add support for leases.

### DIFF
--- a/examples/gen-addresses/main.go
+++ b/examples/gen-addresses/main.go
@@ -115,7 +115,7 @@ func main() {
 	// Sign a sample transaction using this library, *not* kmd
 	genID := txParams.GenesisID
 	genHash := txParams.GenesisHash
-	tx, err := transaction.MakePaymentTxn(addresses[0], addresses[1], 1, 100, 300, 400, nil, "", genID, genHash)
+	tx, err := transaction.MakePaymentTxn(addresses[0], addresses[1], 1, 100, 300, 400, nil, "", genID, genHash, [32]byte{})
 	if err != nil {
 		fmt.Printf("Error creating transaction: %s\n", err)
 		return

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -14,7 +14,7 @@ const MinTxnFee = 1000
 // MakePaymentTxn constructs a payment transaction using the passed parameters.
 // `from` and `to` addresses should be checksummed, human-readable addresses
 // fee is fee per byte as received from algod SuggestedFee API call
-func MakePaymentTxn(from, to string, fee, amount, firstRound, lastRound uint64, note []byte, closeRemainderTo, genesisID string, genesisHash []byte) (types.Transaction, error) {
+func MakePaymentTxn(from, to string, fee, amount, firstRound, lastRound uint64, note []byte, closeRemainderTo, genesisID string, genesisHash []byte, lease [32]byte) (types.Transaction, error) {
 	// Decode from address
 	fromAddr, err := types.DecodeAddress(from)
 	if err != nil {
@@ -55,6 +55,7 @@ func MakePaymentTxn(from, to string, fee, amount, firstRound, lastRound uint64, 
 			Note:        note,
 			GenesisID:   genesisID,
 			GenesisHash: gh,
+			Lease:       lease,
 		},
 		PaymentTxnFields: types.PaymentTxnFields{
 			Receiver:         toAddr,
@@ -80,8 +81,8 @@ func MakePaymentTxn(from, to string, fee, amount, firstRound, lastRound uint64, 
 // MakePaymentTxnWithFlatFee constructs a payment transaction using the passed parameters.
 // `from` and `to` addresses should be checksummed, human-readable addresses
 // fee is a flat fee
-func MakePaymentTxnWithFlatFee(from, to string, fee, amount, firstRound, lastRound uint64, note []byte, closeRemainderTo, genesisID string, genesisHash []byte) (types.Transaction, error) {
-	tx, err := MakePaymentTxn(from, to, fee, amount, firstRound, lastRound, note, closeRemainderTo, genesisID, genesisHash)
+func MakePaymentTxnWithFlatFee(from, to string, fee, amount, firstRound, lastRound uint64, note []byte, closeRemainderTo, genesisID string, genesisHash []byte, lease [32]byte) (types.Transaction, error) {
+	tx, err := MakePaymentTxn(from, to, fee, amount, firstRound, lastRound, note, closeRemainderTo, genesisID, genesisHash, lease)
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -108,7 +109,7 @@ func MakePaymentTxnWithFlatFee(from, to string, fee, amount, firstRound, lastRou
 // - voteFirst is the first round this participation key is valid
 // - voteLast is the last round this participation key is valid
 // - voteKeyDilution is the dilution for the 2-level participation key
-func MakeKeyRegTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID string, genesisHash string,
+func MakeKeyRegTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID string, genesisHash string, lease [32]byte,
 	voteKey, selectionKey string, voteFirst, voteLast, voteKeyDilution uint64) (types.Transaction, error) {
 	// Decode account address
 	accountAddr, err := types.DecodeAddress(account)
@@ -141,6 +142,7 @@ func MakeKeyRegTxn(account string, feePerByte, firstRound, lastRound uint64, not
 			Note:        note,
 			GenesisHash: types.Digest(ghBytes),
 			GenesisID:   genesisID,
+			Lease:       lease,
 		},
 		KeyregTxnFields: types.KeyregTxnFields{
 			VotePK:          types.VotePK(votePKBytes),
@@ -179,9 +181,9 @@ func MakeKeyRegTxn(account string, feePerByte, firstRound, lastRound uint64, not
 // - voteFirst is the first round this participation key is valid
 // - voteLast is the last round this participation key is valid
 // - voteKeyDilution is the dilution for the 2-level participation key
-func MakeKeyRegTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID string, genesisHash string,
+func MakeKeyRegTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID string, genesisHash string, lease [32]byte,
 	voteKey, selectionKey string, voteFirst, voteLast, voteKeyDilution uint64) (types.Transaction, error) {
-	tx, err := MakeKeyRegTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash, voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution)
+	tx, err := MakeKeyRegTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash, lease, voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution)
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -205,7 +207,7 @@ func MakeKeyRegTxnWithFlatFee(account string, fee, firstRound, lastRound uint64,
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // Asset creation parameters:
 // - see asset.go
-func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
+func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
 	total uint64, defaultFrozen bool, manager, reserve, freeze, clawback string,
 	unitName, assetName, url, metadataHash string) (types.Transaction, error) {
 	var tx types.Transaction
@@ -282,6 +284,7 @@ func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64
 		GenesisHash: types.Digest(ghBytes),
 		GenesisID:   genesisID,
 		Note:        note,
+		Lease:       lease,
 	}
 
 	// Update fee
@@ -314,7 +317,7 @@ func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // - index is the asset index id
 // - for newManager, newReserve, newFreeze, newClawback see asset.go
-func MakeAssetConfigTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
+func MakeAssetConfigTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
 	index uint64, newManager, newReserve, newFreeze, newClawback string) (types.Transaction, error) {
 	var tx types.Transaction
 
@@ -338,6 +341,7 @@ func MakeAssetConfigTxn(account string, feePerByte, firstRound, lastRound uint64
 		GenesisHash: ghBytes,
 		GenesisID:   genesisID,
 		Note:        note,
+		Lease:       lease,
 	}
 
 	tx.ConfigAsset = types.AssetIndex(index)
@@ -388,7 +392,7 @@ func MakeAssetConfigTxn(account string, feePerByte, firstRound, lastRound uint64
 // transferAssetBuilder is a helper that builds asset transfer transactions:
 // either a normal asset transfer, or an asset revocation
 func transferAssetBuilder(account, recipient, closeAssetsTo, revocationTarget string, amount, feePerByte,
-	firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, index uint64) (types.Transaction, error) {
+	firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
 	var tx types.Transaction
 	tx.Type = types.AssetTransferTx
 
@@ -410,6 +414,7 @@ func transferAssetBuilder(account, recipient, closeAssetsTo, revocationTarget st
 		GenesisHash: types.Digest(ghBytes),
 		GenesisID:   genesisID,
 		Note:        note,
+		Lease:       lease,
 	}
 
 	tx.XferAsset = types.AssetIndex(index)
@@ -466,10 +471,10 @@ func transferAssetBuilder(account, recipient, closeAssetsTo, revocationTarget st
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // - index is the asset index
 func MakeAssetTransferTxn(account, recipient, closeAssetsTo string, amount, feePerByte, firstRound, lastRound uint64, note []byte,
-	genesisID, genesisHash string, index uint64) (types.Transaction, error) {
+	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
 	revocationTarget := "" // no asset revocation, this is normal asset transfer
 	return transferAssetBuilder(account, recipient, closeAssetsTo, revocationTarget, amount, feePerByte, firstRound, lastRound,
-		note, genesisID, genesisHash, index)
+		note, genesisID, genesisHash, lease, index)
 }
 
 // MakeAssetAcceptanceTxn creates a tx for marking an account as willing to accept the given asset
@@ -482,9 +487,9 @@ func MakeAssetTransferTxn(account, recipient, closeAssetsTo string, amount, feeP
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // - index is the asset index
 func MakeAssetAcceptanceTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte,
-	genesisID, genesisHash string, index uint64) (types.Transaction, error) {
+	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
 	return MakeAssetTransferTxn(account, account, "", 0,
-		feePerByte, firstRound, lastRound, note, genesisID, genesisHash, index)
+		feePerByte, firstRound, lastRound, note, genesisID, genesisHash, lease, index)
 }
 
 // MakeAssetRevocationTxn creates a tx for revoking an asset from an account and sending it to another
@@ -499,10 +504,10 @@ func MakeAssetAcceptanceTxn(account string, feePerByte, firstRound, lastRound ui
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // - index is the asset index
 func MakeAssetRevocationTxn(account, target, recipient string, amount, feePerByte, firstRound, lastRound uint64, note []byte,
-	genesisID, genesisHash string, index uint64) (types.Transaction, error) {
+	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
 	closeAssetsTo := "" // no close-out, this is an asset revocation
 	return transferAssetBuilder(account, recipient, closeAssetsTo, target, amount, feePerByte, firstRound, lastRound,
-		note, genesisID, genesisHash, index)
+		note, genesisID, genesisHash, lease, index)
 }
 
 // MakeAssetDestroyTxn creates a tx template for destroying an asset, removing it from the record.
@@ -514,10 +519,10 @@ func MakeAssetRevocationTxn(account, target, recipient string, amount, feePerByt
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // - index is the asset index
-func MakeAssetDestroyTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
+func MakeAssetDestroyTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
 	index uint64) (types.Transaction, error) {
 	// an asset destroy transaction is just a configuration transaction with AssetParams zeroed
-	tx, err := MakeAssetConfigTxn(account, feePerByte, firstRound, lastRound, note, genesisID, genesisHash,
+	tx, err := MakeAssetConfigTxn(account, feePerByte, firstRound, lastRound, note, genesisID, genesisHash, lease,
 		index, "", "", "", "")
 
 	return tx, err
@@ -535,7 +540,7 @@ func MakeAssetDestroyTxn(account string, feePerByte, firstRound, lastRound uint6
 // - assetIndex is the index for tracking the asset
 // - target is the account to be frozen or unfrozen
 // - newFreezeSetting is the new state of the target account
-func MakeAssetFreezeTxn(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
+func MakeAssetFreezeTxn(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
 	assetIndex uint64, target string, newFreezeSetting bool) (types.Transaction, error) {
 	var tx types.Transaction
 
@@ -559,6 +564,7 @@ func MakeAssetFreezeTxn(account string, fee, firstRound, lastRound uint64, note 
 		GenesisHash: types.Digest(ghBytes),
 		GenesisID:   genesisID,
 		Note:        note,
+		Lease:       lease,
 	}
 
 	tx.FreezeAsset = types.AssetIndex(assetIndex)
@@ -592,9 +598,9 @@ func MakeAssetFreezeTxn(account string, fee, firstRound, lastRound uint64, note 
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // Asset creation parameters:
 // - see asset.go
-func MakeAssetCreateTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
+func MakeAssetCreateTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
 	total uint64, defaultFrozen bool, manager, reserve, freeze, clawback, unitName, assetName, url, metadataHash string) (types.Transaction, error) {
-	tx, err := MakeAssetCreateTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash,
+	tx, err := MakeAssetCreateTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash, lease,
 		total, defaultFrozen, manager, reserve, freeze, clawback, unitName, assetName, url, metadataHash)
 	if err != nil {
 		return types.Transaction{}, err
@@ -613,9 +619,9 @@ func MakeAssetCreateTxnWithFlatFee(account string, fee, firstRound, lastRound ui
 // keys for an asset. An empty string means a zero key (which
 // cannot be changed after becoming zero); to keep a key
 // unchanged, you must specify that key.
-func MakeAssetConfigTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
+func MakeAssetConfigTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
 	index uint64, newManager, newReserve, newFreeze, newClawback string) (types.Transaction, error) {
-	tx, err := MakeAssetConfigTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash,
+	tx, err := MakeAssetConfigTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash, lease,
 		index, newManager, newReserve, newFreeze, newClawback)
 	if err != nil {
 		return types.Transaction{}, err
@@ -642,9 +648,9 @@ func MakeAssetConfigTxnWithFlatFee(account string, fee, firstRound, lastRound ui
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // - index is the asset index
 func MakeAssetTransferTxnWithFlatFee(account, recipient, closeAssetsTo string, amount, fee, firstRound, lastRound uint64, note []byte,
-	genesisID, genesisHash string, index uint64) (types.Transaction, error) {
+	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
 	tx, err := MakeAssetTransferTxn(account, recipient, closeAssetsTo, amount,
-		fee, firstRound, lastRound, note, genesisID, genesisHash, index)
+		fee, firstRound, lastRound, note, genesisID, genesisHash, lease, index)
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -666,9 +672,9 @@ func MakeAssetTransferTxnWithFlatFee(account, recipient, closeAssetsTo string, a
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // - index is the asset index
 func MakeAssetAcceptanceTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte,
-	genesisID, genesisHash string, index uint64) (types.Transaction, error) {
+	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
 	tx, err := MakeAssetTransferTxnWithFlatFee(account, account, "", 0,
-		fee, firstRound, lastRound, note, genesisID, genesisHash, index)
+		fee, firstRound, lastRound, note, genesisID, genesisHash, lease, index)
 	return tx, err
 }
 
@@ -684,9 +690,9 @@ func MakeAssetAcceptanceTxnWithFlatFee(account string, fee, firstRound, lastRoun
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // - index is the asset index
 func MakeAssetRevocationTxnWithFlatFee(account, target, recipient string, amount, fee, firstRound, lastRound uint64, note []byte,
-	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
+	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
 	tx, err := MakeAssetRevocationTxn(account, target, recipient, amount, fee, firstRound, lastRound,
-		note, genesisID, genesisHash, index)
+		note, genesisID, genesisHash, lease, index)
 
 	if err != nil {
 		return types.Transaction{}, err
@@ -709,17 +715,17 @@ func MakeAssetRevocationTxnWithFlatFee(account, target, recipient string, amount
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // - index is the asset index
-func MakeAssetDestroyTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
+func MakeAssetDestroyTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
 	creator string, index uint64) (types.Transaction, error) {
-	tx, err := MakeAssetConfigTxnWithFlatFee(account, fee, firstRound, lastRound, note, genesisID, genesisHash,
+	tx, err := MakeAssetConfigTxnWithFlatFee(account, fee, firstRound, lastRound, note, genesisID, genesisHash, lease,
 		index, "", "", "", "")
 	return tx, err
 }
 
 // MakeAssetFreezeTxnWithFlatFee is as MakeAssetFreezeTxn, but taking a flat fee rather than a fee per byte.
-func MakeAssetFreezeTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
+func MakeAssetFreezeTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
 	creator string, assetIndex uint64, target string, newFreezeSetting bool) (types.Transaction, error) {
-	tx, err := MakeAssetFreezeTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash,
+	tx, err := MakeAssetFreezeTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash, lease,
 		assetIndex, target, newFreezeSetting)
 	if err != nil {
 		return types.Transaction{}, err

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -14,6 +14,7 @@ const MinTxnFee = 1000
 // MakePaymentTxn constructs a payment transaction using the passed parameters.
 // `from` and `to` addresses should be checksummed, human-readable addresses
 // fee is fee per byte as received from algod SuggestedFee API call
+// for information on leases, see types/transaction.go
 func MakePaymentTxn(from, to string, fee, amount, firstRound, lastRound uint64, note []byte, closeRemainderTo, genesisID string, genesisHash []byte, lease [32]byte) (types.Transaction, error) {
 	// Decode from address
 	fromAddr, err := types.DecodeAddress(from)
@@ -103,6 +104,7 @@ func MakePaymentTxnWithFlatFee(from, to string, fee, amount, firstRound, lastRou
 // - note is a byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - lease - for information on leases, see types/transaction.go
 // KeyReg parameters:
 // - votePK is a base64-encoded string corresponding to the root participation public key
 // - selectionKey is a base64-encoded string corresponding to the vrf public key
@@ -175,6 +177,7 @@ func MakeKeyRegTxn(account string, feePerByte, firstRound, lastRound uint64, not
 // - note is a byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - lease - for information on leases, see types/transaction.go
 // KeyReg parameters:
 // - votePK is a base64-encoded string corresponding to the root participation public key
 // - selectionKey is a base64-encoded string corresponding to the vrf public key
@@ -205,6 +208,7 @@ func MakeKeyRegTxnWithFlatFee(account string, fee, firstRound, lastRound uint64,
 // - note is a byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - lease - for information on leases, see types/transaction.go
 // Asset creation parameters:
 // - see asset.go
 func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
@@ -315,6 +319,7 @@ func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64
 // - note is an arbitrary byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - lease - for information on leases, see types/transaction.go
 // - index is the asset index id
 // - for newManager, newReserve, newFreeze, newClawback see asset.go
 func MakeAssetConfigTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
@@ -469,6 +474,7 @@ func transferAssetBuilder(account, recipient, closeAssetsTo, revocationTarget st
 // - note is an arbitrary byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - lease - for information on leases, see types/transaction.go
 // - index is the asset index
 func MakeAssetTransferTxn(account, recipient, closeAssetsTo string, amount, feePerByte, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
@@ -485,6 +491,7 @@ func MakeAssetTransferTxn(account, recipient, closeAssetsTo string, amount, feeP
 // - note is an arbitrary byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - lease - for information on leases, see types/transaction.go
 // - index is the asset index
 func MakeAssetAcceptanceTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
@@ -502,6 +509,7 @@ func MakeAssetAcceptanceTxn(account string, feePerByte, firstRound, lastRound ui
 // - note is an arbitrary byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - lease - for information on leases, see types/transaction.go
 // - index is the asset index
 func MakeAssetRevocationTxn(account, target, recipient string, amount, feePerByte, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
@@ -518,6 +526,7 @@ func MakeAssetRevocationTxn(account, target, recipient string, amount, feePerByt
 // - lastRound is the last round this txn is valid
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - lease - for information on leases, see types/transaction.go
 // - index is the asset index
 func MakeAssetDestroyTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
 	index uint64) (types.Transaction, error) {
@@ -537,6 +546,7 @@ func MakeAssetDestroyTxn(account string, feePerByte, firstRound, lastRound uint6
 // - note is an optional arbitrary byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - lease - for information on leases, see types/transaction.go
 // - assetIndex is the index for tracking the asset
 // - target is the account to be frozen or unfrozen
 // - newFreezeSetting is the new state of the target account
@@ -596,6 +606,7 @@ func MakeAssetFreezeTxn(account string, fee, firstRound, lastRound uint64, note 
 // - lastRound is the last round this txn is valid
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - lease - for information on leases, see types/transaction.go
 // Asset creation parameters:
 // - see asset.go
 func MakeAssetCreateTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
@@ -646,6 +657,7 @@ func MakeAssetConfigTxnWithFlatFee(account string, fee, firstRound, lastRound ui
 // - lastRound is the last round this txn is valid
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - lease - for information on leases, see types/transaction.go
 // - index is the asset index
 func MakeAssetTransferTxnWithFlatFee(account, recipient, closeAssetsTo string, amount, fee, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
@@ -670,6 +682,7 @@ func MakeAssetTransferTxnWithFlatFee(account, recipient, closeAssetsTo string, a
 // - lastRound is the last round this txn is valid
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - lease - for information on leases, see types/transaction.go
 // - index is the asset index
 func MakeAssetAcceptanceTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
@@ -688,6 +701,7 @@ func MakeAssetAcceptanceTxnWithFlatFee(account string, fee, firstRound, lastRoun
 // - note is an arbitrary byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - lease - for information on leases, see types/transaction.go
 // - index is the asset index
 func MakeAssetRevocationTxnWithFlatFee(account, target, recipient string, amount, fee, firstRound, lastRound uint64, note []byte,
 	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
@@ -714,6 +728,7 @@ func MakeAssetRevocationTxnWithFlatFee(account, target, recipient string, amount
 // - lastRound is the last round this txn is valid
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
+// - lease - for information on leases, see types/transaction.go
 // - index is the asset index
 func MakeAssetDestroyTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
 	creator string, index uint64) (types.Transaction, error) {

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -61,9 +61,9 @@ func TestMakePaymentTxn2(t *testing.T) {
 func TestMakePaymentTxnWithLease(t *testing.T) {
 	const fromAddress = "47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU"
 	const toAddress = "PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI"
-	const referenceTxID = "5FJDJD5LMZC3EHUYYJNH5I23U4X6H2KXABNDGPIL557ZMJ33GZHQ"
+	const referenceTxID = "7BG6COBZKF6I6W5XY72ZE4HXV6LLZ6ENSR6DASEGSTXYXR4XJOOQ"
 	const mn = "advice pudding treat near rule blouse same whisper inner electric quit surface sunny dismiss leader blood seat clown cost exist hospital century reform able sponsor"
-	const golden = "gqNzaWfEQPhUAZ3xkDDcc8FvOVo6UinzmKBCqs0woYSfodlmBMfQvGbeUx3Srxy3dyJDzv7rLm26BRv9FnL2/AuT7NYfiAWjdHhui6NhbXTNA+ilY2xvc2XEIEDpNJKIJWTLzpxZpptnVCaJ6aHDoqnqW2Wm6KRCH/xXo2ZlZc0EmKJmds0wsqNnZW6sZGV2bmV0LXYzMy4womdoxCAmCyAJoJOohot5WHIvpeVG7eftF+TYXEx4r7BFJpDt0qJsds00mqRub3RlxAjqABVHQ2y/lqNyY3bEIHts4k/rW6zAsWTinCIsV/X2PcOH1DkEglhBHF/hD3wCo3NuZMQg5/D4TQaBHfnzHI2HixFV9GcdUaGFwgCQhmf0SVhwaKGkdHlwZaNwYXk="
+	const golden = "gqNzaWfEQOMmFSIKsZvpW0txwzhmbgQjxv6IyN7BbV5sZ2aNgFbVcrWUnqPpQQxfPhV/wdu9jzEPUU1jAujYtcNCxJ7ONgejdHhujKNhbXTNA+ilY2xvc2XEIEDpNJKIJWTLzpxZpptnVCaJ6aHDoqnqW2Wm6KRCH/xXo2ZlZc0FLKJmds0wsqNnZW6sZGV2bmV0LXYzMy4womdoxCAmCyAJoJOohot5WHIvpeVG7eftF+TYXEx4r7BFJpDt0qJsds00mqJseMQgAQIDBAECAwQBAgMEAQIDBAECAwQBAgMEAQIDBAECAwSkbm90ZcQI6gAVR0Nsv5ajcmN2xCB7bOJP61uswLFk4pwiLFf19j3Dh9Q5BIJYQRxf4Q98AqNzbmTEIOfw+E0GgR358xyNh4sRVfRnHVGhhcIAkIZn9ElYcGihpHR5cGWjcGF5"
 	gh := byteFromBase64("JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=")
 
 	lease := [32]byte{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -34,7 +34,7 @@ func TestMakePaymentTxn(t *testing.T) {
 	const golden = "gqNzaWfEQPhUAZ3xkDDcc8FvOVo6UinzmKBCqs0woYSfodlmBMfQvGbeUx3Srxy3dyJDzv7rLm26BRv9FnL2/AuT7NYfiAWjdHhui6NhbXTNA+ilY2xvc2XEIEDpNJKIJWTLzpxZpptnVCaJ6aHDoqnqW2Wm6KRCH/xXo2ZlZc0EmKJmds0wsqNnZW6sZGV2bmV0LXYzMy4womdoxCAmCyAJoJOohot5WHIvpeVG7eftF+TYXEx4r7BFJpDt0qJsds00mqRub3RlxAjqABVHQ2y/lqNyY3bEIHts4k/rW6zAsWTinCIsV/X2PcOH1DkEglhBHF/hD3wCo3NuZMQg5/D4TQaBHfnzHI2HixFV9GcdUaGFwgCQhmf0SVhwaKGkdHlwZaNwYXk="
 	gh := byteFromBase64("JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=")
 
-	txn, err := MakePaymentTxn(fromAddress, toAddress, 4, 1000, 12466, 13466, byteFromBase64("6gAVR0Nsv5Y="), "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA", "devnet-v33.0", gh, nil)
+	txn, err := MakePaymentTxn(fromAddress, toAddress, 4, 1000, 12466, 13466, byteFromBase64("6gAVR0Nsv5Y="), "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA", "devnet-v33.0", gh, [32]byte{})
 	require.NoError(t, err)
 
 	key, err := mnemonic.ToPrivateKey(mn)
@@ -53,7 +53,7 @@ func TestMakePaymentTxn2(t *testing.T) {
 	const fromAddress = "47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU"
 	const toAddress = "PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI"
 
-	_, err := MakePaymentTxn(fromAddress, toAddress, 4, 1000, 12466, 13466, byteFromBase64("6gAVR0Nsv5Y="), "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA", "devnet-v33.0", []byte{}, nil)
+	_, err := MakePaymentTxn(fromAddress, toAddress, 4, 1000, 12466, 13466, byteFromBase64("6gAVR0Nsv5Y="), "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA", "devnet-v33.0", []byte{}, [32]byte{})
 	require.Error(t, err)
 
 }
@@ -117,7 +117,7 @@ func TestKeyRegTxn(t *testing.T) {
 
 func TestMakeKeyRegTxn(t *testing.T) {
 	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
-	tx, err := MakeKeyRegTxn(addr, 10, 322575, 323575, []byte{45, 67}, "", "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=", nil,
+	tx, err := MakeKeyRegTxn(addr, 10, 322575, 323575, []byte{45, 67}, "", "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=", [32]byte{},
 		"Kv7QI7chi1y6axoy+t7wzAVpePqRq/rkjzWh/RMYyLo=", "bPgrv4YogPcdaUAxrt1QysYZTVyRAuUMD4zQmCu9llc=", 10000, 10111, 11)
 	require.NoError(t, err)
 
@@ -157,7 +157,7 @@ func TestMakeAssetCreateTxn(t *testing.T) {
 	const assetName = "testcoin"
 	const testURL = "website"
 	const metadataHash = "fACPO4nRgO55j1ndAK3W6Sgc4APkcyFh"
-	tx, err := MakeAssetCreateTxn(addr, 10, 322575, 323575, nil, "", genesisHash, nil,
+	tx, err := MakeAssetCreateTxn(addr, 10, 322575, 323575, nil, "", genesisHash, [32]byte{},
 		total, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName, testURL, metadataHash)
 	require.NoError(t, err)
 
@@ -204,7 +204,7 @@ func TestMakeAssetConfigTxn(t *testing.T) {
 	const freeze = addr
 	const clawback = addr
 	const assetIndex = 1234
-	tx, err := MakeAssetConfigTxn(addr, 10, 322575, 323575, nil, "", genesisHash, nil,
+	tx, err := MakeAssetConfigTxn(addr, 10, 322575, 323575, nil, "", genesisHash, [32]byte{},
 		assetIndex, manager, reserve, freeze, clawback)
 	require.NoError(t, err)
 
@@ -246,7 +246,7 @@ func TestMakeAssetDestroyTxn(t *testing.T) {
 	const assetIndex = 1
 	const firstValidRound = 322575
 	const lastValidRound = 323575
-	tx, err := MakeAssetDestroyTxn(creator, 10, firstValidRound, lastValidRound, nil, "", genesisHash, nil, assetIndex)
+	tx, err := MakeAssetDestroyTxn(creator, 10, firstValidRound, lastValidRound, nil, "", genesisHash, [32]byte{}, assetIndex)
 	require.NoError(t, err)
 
 	a, err := types.DecodeAddress(creator)
@@ -283,7 +283,7 @@ func TestMakeAssetFreezeTxn(t *testing.T) {
 	const lastValidRound = 323576
 	const freezeSetting = true
 	const target = addr
-	tx, err := MakeAssetFreezeTxn(addr, 10, firstValidRound, lastValidRound, nil, "", genesisHash, nil, assetIndex, target, freezeSetting)
+	tx, err := MakeAssetFreezeTxn(addr, 10, firstValidRound, lastValidRound, nil, "", genesisHash, [32]byte{}, assetIndex, target, freezeSetting)
 	require.NoError(t, err)
 
 	a, err := types.DecodeAddress(addr)
@@ -327,7 +327,7 @@ func TestMakeAssetTransferTxn(t *testing.T) {
 	const amountToSend = 1
 
 	tx, err := MakeAssetTransferTxn(sender, recipient, closeAssetsTo, amountToSend, 10, firstValidRound,
-		lastValidRound, nil, "", genesisHash, nil, assetIndex)
+		lastValidRound, nil, "", genesisHash, [32]byte{}, assetIndex)
 	require.NoError(t, err)
 
 	sendAddr, err := types.DecodeAddress(sender)
@@ -375,7 +375,7 @@ func TestMakeAssetAcceptanceTxn(t *testing.T) {
 	const lastValidRound = 323575
 
 	tx, err := MakeAssetAcceptanceTxn(sender, 10, firstValidRound,
-		lastValidRound, nil, "", genesisHash, nil, assetIndex)
+		lastValidRound, nil, "", genesisHash, [32]byte{}, assetIndex)
 	require.NoError(t, err)
 
 	sendAddr, err := types.DecodeAddress(sender)
@@ -418,7 +418,7 @@ func TestMakeAssetRevocationTransaction(t *testing.T) {
 	const amountToSend = 1
 
 	tx, err := MakeAssetRevocationTxn(revoker, revoked, recipient, amountToSend, 10, firstValidRound,
-		lastValidRound, nil, "", genesisHash, nil, assetIndex)
+		lastValidRound, nil, "", genesisHash, [32]byte{}, assetIndex)
 	require.NoError(t, err)
 
 	sendAddr, err := types.DecodeAddress(revoker)
@@ -473,7 +473,7 @@ func TestComputeGroupID(t *testing.T) {
 	note1 := byteFromBase64("wRKw5cJ0CMo=")
 	tx1, err := MakePaymentTxnWithFlatFee(
 		fromAddress, toAddress, fee, amount, firstRound1, firstRound1+1000,
-		note1, "", genesisID, genesisHash, nil,
+		note1, "", genesisID, genesisHash, [32]byte{},
 	)
 	require.NoError(t, err)
 
@@ -481,7 +481,7 @@ func TestComputeGroupID(t *testing.T) {
 	note2 := byteFromBase64("dBlHI6BdrIg=")
 	tx2, err := MakePaymentTxnWithFlatFee(
 		fromAddress, toAddress, fee, amount, firstRound2, firstRound2+1000,
-		note2, "", genesisID, genesisHash, nil,
+		note2, "", genesisID, genesisHash, [32]byte{},
 	)
 	require.NoError(t, err)
 
@@ -538,7 +538,7 @@ func TestLogicSig(t *testing.T) {
 
 	tx, err := MakePaymentTxnWithFlatFee(
 		fromAddress, toAddress, fee, amount, firstRound, firstRound+1000,
-		note, "", genesisID, genesisHash, nil,
+		note, "", genesisID, genesisHash, [32]byte{},
 	)
 	require.NoError(t, err)
 

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -34,7 +34,7 @@ func TestMakePaymentTxn(t *testing.T) {
 	const golden = "gqNzaWfEQPhUAZ3xkDDcc8FvOVo6UinzmKBCqs0woYSfodlmBMfQvGbeUx3Srxy3dyJDzv7rLm26BRv9FnL2/AuT7NYfiAWjdHhui6NhbXTNA+ilY2xvc2XEIEDpNJKIJWTLzpxZpptnVCaJ6aHDoqnqW2Wm6KRCH/xXo2ZlZc0EmKJmds0wsqNnZW6sZGV2bmV0LXYzMy4womdoxCAmCyAJoJOohot5WHIvpeVG7eftF+TYXEx4r7BFJpDt0qJsds00mqRub3RlxAjqABVHQ2y/lqNyY3bEIHts4k/rW6zAsWTinCIsV/X2PcOH1DkEglhBHF/hD3wCo3NuZMQg5/D4TQaBHfnzHI2HixFV9GcdUaGFwgCQhmf0SVhwaKGkdHlwZaNwYXk="
 	gh := byteFromBase64("JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=")
 
-	txn, err := MakePaymentTxn(fromAddress, toAddress, 4, 1000, 12466, 13466, byteFromBase64("6gAVR0Nsv5Y="), "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA", "devnet-v33.0", gh)
+	txn, err := MakePaymentTxn(fromAddress, toAddress, 4, 1000, 12466, 13466, byteFromBase64("6gAVR0Nsv5Y="), "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA", "devnet-v33.0", gh, nil)
 	require.NoError(t, err)
 
 	key, err := mnemonic.ToPrivateKey(mn)
@@ -48,14 +48,37 @@ func TestMakePaymentTxn(t *testing.T) {
 	require.Equal(t, referenceTxID, id)
 }
 
-// should fail on a lack of GenesisHash
+// should fail on a lack of GenesisH[32]byte{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}ash
 func TestMakePaymentTxn2(t *testing.T) {
 	const fromAddress = "47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU"
 	const toAddress = "PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI"
 
-	_, err := MakePaymentTxn(fromAddress, toAddress, 4, 1000, 12466, 13466, byteFromBase64("6gAVR0Nsv5Y="), "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA", "devnet-v33.0", []byte{})
+	_, err := MakePaymentTxn(fromAddress, toAddress, 4, 1000, 12466, 13466, byteFromBase64("6gAVR0Nsv5Y="), "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA", "devnet-v33.0", []byte{}, nil)
 	require.Error(t, err)
 
+}
+
+func TestMakePaymentTxnWithLease(t *testing.T) {
+	const fromAddress = "47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU"
+	const toAddress = "PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI"
+	const referenceTxID = "5FJDJD5LMZC3EHUYYJNH5I23U4X6H2KXABNDGPIL557ZMJ33GZHQ"
+	const mn = "advice pudding treat near rule blouse same whisper inner electric quit surface sunny dismiss leader blood seat clown cost exist hospital century reform able sponsor"
+	const golden = "gqNzaWfEQPhUAZ3xkDDcc8FvOVo6UinzmKBCqs0woYSfodlmBMfQvGbeUx3Srxy3dyJDzv7rLm26BRv9FnL2/AuT7NYfiAWjdHhui6NhbXTNA+ilY2xvc2XEIEDpNJKIJWTLzpxZpptnVCaJ6aHDoqnqW2Wm6KRCH/xXo2ZlZc0EmKJmds0wsqNnZW6sZGV2bmV0LXYzMy4womdoxCAmCyAJoJOohot5WHIvpeVG7eftF+TYXEx4r7BFJpDt0qJsds00mqRub3RlxAjqABVHQ2y/lqNyY3bEIHts4k/rW6zAsWTinCIsV/X2PcOH1DkEglhBHF/hD3wCo3NuZMQg5/D4TQaBHfnzHI2HixFV9GcdUaGFwgCQhmf0SVhwaKGkdHlwZaNwYXk="
+	gh := byteFromBase64("JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=")
+
+	lease := [32]byte{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}
+	txn, err := MakePaymentTxn(fromAddress, toAddress, 4, 1000, 12466, 13466, byteFromBase64("6gAVR0Nsv5Y="), "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA", "devnet-v33.0", gh, lease)
+	require.NoError(t, err)
+
+	key, err := mnemonic.ToPrivateKey(mn)
+	require.NoError(t, err)
+
+	id, bytes, err := crypto.SignTransaction(key, txn)
+
+	stxBytes := byteFromBase64(golden)
+	require.Equal(t, stxBytes, bytes)
+
+	require.Equal(t, referenceTxID, id)
 }
 
 func TestKeyRegTxn(t *testing.T) {
@@ -94,7 +117,7 @@ func TestKeyRegTxn(t *testing.T) {
 
 func TestMakeKeyRegTxn(t *testing.T) {
 	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
-	tx, err := MakeKeyRegTxn(addr, 10, 322575, 323575, []byte{45, 67}, "", "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+	tx, err := MakeKeyRegTxn(addr, 10, 322575, 323575, []byte{45, 67}, "", "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=", nil,
 		"Kv7QI7chi1y6axoy+t7wzAVpePqRq/rkjzWh/RMYyLo=", "bPgrv4YogPcdaUAxrt1QysYZTVyRAuUMD4zQmCu9llc=", 10000, 10111, 11)
 	require.NoError(t, err)
 
@@ -134,7 +157,7 @@ func TestMakeAssetCreateTxn(t *testing.T) {
 	const assetName = "testcoin"
 	const testURL = "website"
 	const metadataHash = "fACPO4nRgO55j1ndAK3W6Sgc4APkcyFh"
-	tx, err := MakeAssetCreateTxn(addr, 10, 322575, 323575, nil, "", genesisHash,
+	tx, err := MakeAssetCreateTxn(addr, 10, 322575, 323575, nil, "", genesisHash, nil,
 		total, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName, testURL, metadataHash)
 	require.NoError(t, err)
 
@@ -181,7 +204,7 @@ func TestMakeAssetConfigTxn(t *testing.T) {
 	const freeze = addr
 	const clawback = addr
 	const assetIndex = 1234
-	tx, err := MakeAssetConfigTxn(addr, 10, 322575, 323575, nil, "", genesisHash,
+	tx, err := MakeAssetConfigTxn(addr, 10, 322575, 323575, nil, "", genesisHash, nil,
 		assetIndex, manager, reserve, freeze, clawback)
 	require.NoError(t, err)
 
@@ -223,7 +246,7 @@ func TestMakeAssetDestroyTxn(t *testing.T) {
 	const assetIndex = 1
 	const firstValidRound = 322575
 	const lastValidRound = 323575
-	tx, err := MakeAssetDestroyTxn(creator, 10, firstValidRound, lastValidRound, nil, "", genesisHash, assetIndex)
+	tx, err := MakeAssetDestroyTxn(creator, 10, firstValidRound, lastValidRound, nil, "", genesisHash, nil, assetIndex)
 	require.NoError(t, err)
 
 	a, err := types.DecodeAddress(creator)
@@ -260,7 +283,7 @@ func TestMakeAssetFreezeTxn(t *testing.T) {
 	const lastValidRound = 323576
 	const freezeSetting = true
 	const target = addr
-	tx, err := MakeAssetFreezeTxn(addr, 10, firstValidRound, lastValidRound, nil, "", genesisHash, assetIndex, target, freezeSetting)
+	tx, err := MakeAssetFreezeTxn(addr, 10, firstValidRound, lastValidRound, nil, "", genesisHash, nil, assetIndex, target, freezeSetting)
 	require.NoError(t, err)
 
 	a, err := types.DecodeAddress(addr)
@@ -304,7 +327,7 @@ func TestMakeAssetTransferTxn(t *testing.T) {
 	const amountToSend = 1
 
 	tx, err := MakeAssetTransferTxn(sender, recipient, closeAssetsTo, amountToSend, 10, firstValidRound,
-		lastValidRound, nil, "", genesisHash, assetIndex)
+		lastValidRound, nil, "", genesisHash, nil, assetIndex)
 	require.NoError(t, err)
 
 	sendAddr, err := types.DecodeAddress(sender)
@@ -352,7 +375,7 @@ func TestMakeAssetAcceptanceTxn(t *testing.T) {
 	const lastValidRound = 323575
 
 	tx, err := MakeAssetAcceptanceTxn(sender, 10, firstValidRound,
-		lastValidRound, nil, "", genesisHash, assetIndex)
+		lastValidRound, nil, "", genesisHash, nil, assetIndex)
 	require.NoError(t, err)
 
 	sendAddr, err := types.DecodeAddress(sender)
@@ -395,7 +418,7 @@ func TestMakeAssetRevocationTransaction(t *testing.T) {
 	const amountToSend = 1
 
 	tx, err := MakeAssetRevocationTxn(revoker, revoked, recipient, amountToSend, 10, firstValidRound,
-		lastValidRound, nil, "", genesisHash, assetIndex)
+		lastValidRound, nil, "", genesisHash, nil, assetIndex)
 	require.NoError(t, err)
 
 	sendAddr, err := types.DecodeAddress(revoker)
@@ -450,7 +473,7 @@ func TestComputeGroupID(t *testing.T) {
 	note1 := byteFromBase64("wRKw5cJ0CMo=")
 	tx1, err := MakePaymentTxnWithFlatFee(
 		fromAddress, toAddress, fee, amount, firstRound1, firstRound1+1000,
-		note1, "", genesisID, genesisHash,
+		note1, "", genesisID, genesisHash, nil,
 	)
 	require.NoError(t, err)
 
@@ -458,7 +481,7 @@ func TestComputeGroupID(t *testing.T) {
 	note2 := byteFromBase64("dBlHI6BdrIg=")
 	tx2, err := MakePaymentTxnWithFlatFee(
 		fromAddress, toAddress, fee, amount, firstRound2, firstRound2+1000,
-		note2, "", genesisID, genesisHash,
+		note2, "", genesisID, genesisHash, nil,
 	)
 	require.NoError(t, err)
 
@@ -515,7 +538,7 @@ func TestLogicSig(t *testing.T) {
 
 	tx, err := MakePaymentTxnWithFlatFee(
 		fromAddress, toAddress, fee, amount, firstRound, firstRound+1000,
-		note, "", genesisID, genesisHash,
+		note, "", genesisID, genesisHash, nil,
 	)
 	require.NoError(t, err)
 

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -126,6 +126,13 @@ type Header struct {
 	// transaction group (and, if so, specifies the hash
 	// of a TxGroup).
 	Group Digest `codec:"grp"`
+
+	// Lease enforces mutual exclusion of transactions.  If this field is
+	// nonzero, then once the transaction is confirmed, it acquires the
+	// lease identified by the (Sender, Lease) pair of the transaction until
+	// the LastValid round passes.  While this transaction possesses the
+	// lease, no other transaction specifying this lease can be confirmed.
+	Lease [32]byte `codec:"lx"`
 }
 
 // TxGroup describes a group of transactions that must appear


### PR DESCRIPTION
## Summary
From `types/transaction.go`:
```
	// Lease enforces mutual exclusion of transactions.  If this field is
	// nonzero, then once the transaction is confirmed, it acquires the
	// lease identified by the (Sender, Lease) pair of the transaction until
	// the LastValid round passes.  While this transaction possesses the
	// lease, no other transaction specifying this lease can be confirmed.
	Lease [32]byte `codec:"lx"`
```

### Testing
Added a `golden` test to `transaction_test.go`. Updated transaction builder usage throughout sdk. Tests passed on my machine. `algorand-sdk-testing:steps_test.go` will fail due to argument mismatch, see https://github.com/algorand/algorand-sdk-testing/pull/23

### See also
#79
https://github.com/algorand/algorand-sdk-testing/pull/23
https://github.com/algorand/js-algorand-sdk/pull/82