### PR TITLE
Change leases to be backwards compatible. Revert old lease impl.

### DIFF
--- a/examples/gen-addresses/main.go
+++ b/examples/gen-addresses/main.go
@@ -115,7 +115,7 @@ func main() {
 	// Sign a sample transaction using this library, *not* kmd
 	genID := txParams.GenesisID
 	genHash := txParams.GenesisHash
-	tx, err := transaction.MakePaymentTxn(addresses[0], addresses[1], 1, 100, 300, 400, nil, "", genID, genHash, [32]byte{})
+	tx, err := transaction.MakePaymentTxn(addresses[0], addresses[1], 1, 100, 300, 400, nil, "", genID, genHash)
 	if err != nil {
 		fmt.Printf("Error creating transaction: %s\n", err)
 		return

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -64,7 +64,7 @@ func MakePaymentTxn(from, to string, fee, amount, firstRound, lastRound uint64, 
 	}
 
 	// Update fee
-	eSize, err := estimateSize(tx)
+	eSize, err := tx.EstimateSize()
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -152,7 +152,7 @@ func MakeKeyRegTxn(account string, feePerByte, firstRound, lastRound uint64, not
 	}
 
 	// Update fee
-	eSize, err := estimateSize(tx)
+	eSize, err := tx.EstimateSize()
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -285,7 +285,7 @@ func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64
 	}
 
 	// Update fee
-	eSize, err := estimateSize(tx)
+	eSize, err := tx.EstimateSize()
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -372,7 +372,7 @@ func MakeAssetConfigTxn(account string, feePerByte, firstRound, lastRound uint64
 	}
 
 	// Update fee
-	eSize, err := estimateSize(tx)
+	eSize, err := tx.EstimateSize()
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -439,7 +439,7 @@ func transferAssetBuilder(account, recipient, closeAssetsTo, revocationTarget st
 	tx.AssetAmount = amount
 
 	// Update fee
-	eSize, err := estimateSize(tx)
+	eSize, err := tx.EstimateSize()
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -570,7 +570,7 @@ func MakeAssetFreezeTxn(account string, fee, firstRound, lastRound uint64, note 
 
 	tx.AssetFrozen = newFreezeSetting
 	// Update fee
-	eSize, err := estimateSize(tx)
+	eSize, err := tx.EstimateSize()
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -765,7 +765,7 @@ func AddLease(tx types.Transaction, lease [32]byte, feePerByte uint64) (types.Tr
 	tx.Header.Lease = lease
 	tx.Header.Fee = types.MicroAlgos(feePerByte)
 	// Update fee
-	eSize, err := estimateSize(tx)
+	eSize, err := tx.EstimateSize()
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -791,16 +791,6 @@ func AddLeaseWithFlatFee(tx types.Transaction, lease [32]byte, flatFee uint64) (
 		tx.Fee = MinTxnFee
 	}
 	return tx, nil
-}
-
-// EstimateSize returns the estimated length of the encoded transaction
-func estimateSize(txn types.Transaction) (uint64, error) {
-	key := crypto.GenerateAccount()
-	_, stx, err := crypto.SignTransaction(key.PrivateKey, txn)
-	if err != nil {
-		return 0, err
-	}
-	return uint64(len(stx)), nil
 }
 
 // byte32FromBase64 decodes the input base64 string and outputs a

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -757,6 +757,42 @@ func AssignGroupID(txns []types.Transaction, account string) (result []types.Tra
 	return result, nil
 }
 
+// AddLease adds the passed lease (see types/transaction.go) to the header of the passed transaction
+// - txn: the types.Transaction to modify
+// - lease: the [32]byte lease to add to the header
+// - feePerByte: the new feePerByte
+func AddLease(tx types.Transaction, lease [32]byte, feePerByte uint64) (types.Transaction, error) {
+	tx.Header.Lease = lease
+	tx.Header.Fee = types.MicroAlgos(feePerByte)
+	// Update fee
+	eSize, err := estimateSize(tx)
+	if err != nil {
+		return types.Transaction{}, err
+	}
+	tx.Fee = types.MicroAlgos(eSize * feePerByte)
+
+	if tx.Fee < MinTxnFee {
+		tx.Fee = MinTxnFee
+	}
+	return tx, nil
+}
+
+// AddLeaseWithFlatFee adds the passed lease (see types/transaction.go) to the header of the passed transaction
+// - txn: the types.Transaction to modify
+// - lease: the [32]byte lease to add to the header
+// - feePerByte: the new feePerByte
+func AddLeaseWithFlatFee(tx types.Transaction, lease [32]byte, flatFee uint64) (types.Transaction, error) {
+	tx.Header.Lease = lease
+	tx.Header.Fee = 0
+	// Update fee
+	tx.Fee = types.MicroAlgos(flatFee)
+
+	if tx.Fee < MinTxnFee {
+		tx.Fee = MinTxnFee
+	}
+	return tx, nil
+}
+
 // EstimateSize returns the estimated length of the encoded transaction
 func estimateSize(txn types.Transaction) (uint64, error) {
 	key := crypto.GenerateAccount()

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -14,8 +14,7 @@ const MinTxnFee = 1000
 // MakePaymentTxn constructs a payment transaction using the passed parameters.
 // `from` and `to` addresses should be checksummed, human-readable addresses
 // fee is fee per byte as received from algod SuggestedFee API call
-// for information on leases, see types/transaction.go
-func MakePaymentTxn(from, to string, fee, amount, firstRound, lastRound uint64, note []byte, closeRemainderTo, genesisID string, genesisHash []byte, lease [32]byte) (types.Transaction, error) {
+func MakePaymentTxn(from, to string, fee, amount, firstRound, lastRound uint64, note []byte, closeRemainderTo, genesisID string, genesisHash []byte) (types.Transaction, error) {
 	// Decode from address
 	fromAddr, err := types.DecodeAddress(from)
 	if err != nil {
@@ -56,7 +55,6 @@ func MakePaymentTxn(from, to string, fee, amount, firstRound, lastRound uint64, 
 			Note:        note,
 			GenesisID:   genesisID,
 			GenesisHash: gh,
-			Lease:       lease,
 		},
 		PaymentTxnFields: types.PaymentTxnFields{
 			Receiver:         toAddr,
@@ -82,8 +80,8 @@ func MakePaymentTxn(from, to string, fee, amount, firstRound, lastRound uint64, 
 // MakePaymentTxnWithFlatFee constructs a payment transaction using the passed parameters.
 // `from` and `to` addresses should be checksummed, human-readable addresses
 // fee is a flat fee
-func MakePaymentTxnWithFlatFee(from, to string, fee, amount, firstRound, lastRound uint64, note []byte, closeRemainderTo, genesisID string, genesisHash []byte, lease [32]byte) (types.Transaction, error) {
-	tx, err := MakePaymentTxn(from, to, fee, amount, firstRound, lastRound, note, closeRemainderTo, genesisID, genesisHash, lease)
+func MakePaymentTxnWithFlatFee(from, to string, fee, amount, firstRound, lastRound uint64, note []byte, closeRemainderTo, genesisID string, genesisHash []byte) (types.Transaction, error) {
+	tx, err := MakePaymentTxn(from, to, fee, amount, firstRound, lastRound, note, closeRemainderTo, genesisID, genesisHash)
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -104,14 +102,13 @@ func MakePaymentTxnWithFlatFee(from, to string, fee, amount, firstRound, lastRou
 // - note is a byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
-// - lease - for information on leases, see types/transaction.go
 // KeyReg parameters:
 // - votePK is a base64-encoded string corresponding to the root participation public key
 // - selectionKey is a base64-encoded string corresponding to the vrf public key
 // - voteFirst is the first round this participation key is valid
 // - voteLast is the last round this participation key is valid
 // - voteKeyDilution is the dilution for the 2-level participation key
-func MakeKeyRegTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID string, genesisHash string, lease [32]byte,
+func MakeKeyRegTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID string, genesisHash string,
 	voteKey, selectionKey string, voteFirst, voteLast, voteKeyDilution uint64) (types.Transaction, error) {
 	// Decode account address
 	accountAddr, err := types.DecodeAddress(account)
@@ -144,7 +141,6 @@ func MakeKeyRegTxn(account string, feePerByte, firstRound, lastRound uint64, not
 			Note:        note,
 			GenesisHash: types.Digest(ghBytes),
 			GenesisID:   genesisID,
-			Lease:       lease,
 		},
 		KeyregTxnFields: types.KeyregTxnFields{
 			VotePK:          types.VotePK(votePKBytes),
@@ -177,16 +173,15 @@ func MakeKeyRegTxn(account string, feePerByte, firstRound, lastRound uint64, not
 // - note is a byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
-// - lease - for information on leases, see types/transaction.go
 // KeyReg parameters:
 // - votePK is a base64-encoded string corresponding to the root participation public key
 // - selectionKey is a base64-encoded string corresponding to the vrf public key
 // - voteFirst is the first round this participation key is valid
 // - voteLast is the last round this participation key is valid
 // - voteKeyDilution is the dilution for the 2-level participation key
-func MakeKeyRegTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID string, genesisHash string, lease [32]byte,
+func MakeKeyRegTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID string, genesisHash string,
 	voteKey, selectionKey string, voteFirst, voteLast, voteKeyDilution uint64) (types.Transaction, error) {
-	tx, err := MakeKeyRegTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash, lease, voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution)
+	tx, err := MakeKeyRegTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash, voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution)
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -208,10 +203,9 @@ func MakeKeyRegTxnWithFlatFee(account string, fee, firstRound, lastRound uint64,
 // - note is a byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
-// - lease - for information on leases, see types/transaction.go
 // Asset creation parameters:
 // - see asset.go
-func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
+func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
 	total uint64, defaultFrozen bool, manager, reserve, freeze, clawback string,
 	unitName, assetName, url, metadataHash string) (types.Transaction, error) {
 	var tx types.Transaction
@@ -288,7 +282,6 @@ func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64
 		GenesisHash: types.Digest(ghBytes),
 		GenesisID:   genesisID,
 		Note:        note,
-		Lease:       lease,
 	}
 
 	// Update fee
@@ -319,10 +312,9 @@ func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64
 // - note is an arbitrary byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
-// - lease - for information on leases, see types/transaction.go
 // - index is the asset index id
 // - for newManager, newReserve, newFreeze, newClawback see asset.go
-func MakeAssetConfigTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
+func MakeAssetConfigTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
 	index uint64, newManager, newReserve, newFreeze, newClawback string) (types.Transaction, error) {
 	var tx types.Transaction
 
@@ -346,7 +338,6 @@ func MakeAssetConfigTxn(account string, feePerByte, firstRound, lastRound uint64
 		GenesisHash: ghBytes,
 		GenesisID:   genesisID,
 		Note:        note,
-		Lease:       lease,
 	}
 
 	tx.ConfigAsset = types.AssetIndex(index)
@@ -397,7 +388,7 @@ func MakeAssetConfigTxn(account string, feePerByte, firstRound, lastRound uint64
 // transferAssetBuilder is a helper that builds asset transfer transactions:
 // either a normal asset transfer, or an asset revocation
 func transferAssetBuilder(account, recipient, closeAssetsTo, revocationTarget string, amount, feePerByte,
-	firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
+	firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, index uint64) (types.Transaction, error) {
 	var tx types.Transaction
 	tx.Type = types.AssetTransferTx
 
@@ -419,7 +410,6 @@ func transferAssetBuilder(account, recipient, closeAssetsTo, revocationTarget st
 		GenesisHash: types.Digest(ghBytes),
 		GenesisID:   genesisID,
 		Note:        note,
-		Lease:       lease,
 	}
 
 	tx.XferAsset = types.AssetIndex(index)
@@ -474,13 +464,12 @@ func transferAssetBuilder(account, recipient, closeAssetsTo, revocationTarget st
 // - note is an arbitrary byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
-// - lease - for information on leases, see types/transaction.go
 // - index is the asset index
 func MakeAssetTransferTxn(account, recipient, closeAssetsTo string, amount, feePerByte, firstRound, lastRound uint64, note []byte,
-	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
+	genesisID, genesisHash string, index uint64) (types.Transaction, error) {
 	revocationTarget := "" // no asset revocation, this is normal asset transfer
 	return transferAssetBuilder(account, recipient, closeAssetsTo, revocationTarget, amount, feePerByte, firstRound, lastRound,
-		note, genesisID, genesisHash, lease, index)
+		note, genesisID, genesisHash, index)
 }
 
 // MakeAssetAcceptanceTxn creates a tx for marking an account as willing to accept the given asset
@@ -491,12 +480,11 @@ func MakeAssetTransferTxn(account, recipient, closeAssetsTo string, amount, feeP
 // - note is an arbitrary byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
-// - lease - for information on leases, see types/transaction.go
 // - index is the asset index
 func MakeAssetAcceptanceTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte,
-	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
+	genesisID, genesisHash string, index uint64) (types.Transaction, error) {
 	return MakeAssetTransferTxn(account, account, "", 0,
-		feePerByte, firstRound, lastRound, note, genesisID, genesisHash, lease, index)
+		feePerByte, firstRound, lastRound, note, genesisID, genesisHash, index)
 }
 
 // MakeAssetRevocationTxn creates a tx for revoking an asset from an account and sending it to another
@@ -509,13 +497,12 @@ func MakeAssetAcceptanceTxn(account string, feePerByte, firstRound, lastRound ui
 // - note is an arbitrary byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
-// - lease - for information on leases, see types/transaction.go
 // - index is the asset index
 func MakeAssetRevocationTxn(account, target, recipient string, amount, feePerByte, firstRound, lastRound uint64, note []byte,
-	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
+	genesisID, genesisHash string, index uint64) (types.Transaction, error) {
 	closeAssetsTo := "" // no close-out, this is an asset revocation
 	return transferAssetBuilder(account, recipient, closeAssetsTo, target, amount, feePerByte, firstRound, lastRound,
-		note, genesisID, genesisHash, lease, index)
+		note, genesisID, genesisHash, index)
 }
 
 // MakeAssetDestroyTxn creates a tx template for destroying an asset, removing it from the record.
@@ -526,12 +513,11 @@ func MakeAssetRevocationTxn(account, target, recipient string, amount, feePerByt
 // - lastRound is the last round this txn is valid
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
-// - lease - for information on leases, see types/transaction.go
 // - index is the asset index
-func MakeAssetDestroyTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
+func MakeAssetDestroyTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
 	index uint64) (types.Transaction, error) {
 	// an asset destroy transaction is just a configuration transaction with AssetParams zeroed
-	tx, err := MakeAssetConfigTxn(account, feePerByte, firstRound, lastRound, note, genesisID, genesisHash, lease,
+	tx, err := MakeAssetConfigTxn(account, feePerByte, firstRound, lastRound, note, genesisID, genesisHash,
 		index, "", "", "", "")
 
 	return tx, err
@@ -546,11 +532,10 @@ func MakeAssetDestroyTxn(account string, feePerByte, firstRound, lastRound uint6
 // - note is an optional arbitrary byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
-// - lease - for information on leases, see types/transaction.go
 // - assetIndex is the index for tracking the asset
 // - target is the account to be frozen or unfrozen
 // - newFreezeSetting is the new state of the target account
-func MakeAssetFreezeTxn(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
+func MakeAssetFreezeTxn(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
 	assetIndex uint64, target string, newFreezeSetting bool) (types.Transaction, error) {
 	var tx types.Transaction
 
@@ -574,7 +559,6 @@ func MakeAssetFreezeTxn(account string, fee, firstRound, lastRound uint64, note 
 		GenesisHash: types.Digest(ghBytes),
 		GenesisID:   genesisID,
 		Note:        note,
-		Lease:       lease,
 	}
 
 	tx.FreezeAsset = types.AssetIndex(assetIndex)
@@ -606,12 +590,11 @@ func MakeAssetFreezeTxn(account string, fee, firstRound, lastRound uint64, note 
 // - lastRound is the last round this txn is valid
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
-// - lease - for information on leases, see types/transaction.go
 // Asset creation parameters:
 // - see asset.go
-func MakeAssetCreateTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
+func MakeAssetCreateTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
 	total uint64, defaultFrozen bool, manager, reserve, freeze, clawback, unitName, assetName, url, metadataHash string) (types.Transaction, error) {
-	tx, err := MakeAssetCreateTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash, lease,
+	tx, err := MakeAssetCreateTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash,
 		total, defaultFrozen, manager, reserve, freeze, clawback, unitName, assetName, url, metadataHash)
 	if err != nil {
 		return types.Transaction{}, err
@@ -630,9 +613,9 @@ func MakeAssetCreateTxnWithFlatFee(account string, fee, firstRound, lastRound ui
 // keys for an asset. An empty string means a zero key (which
 // cannot be changed after becoming zero); to keep a key
 // unchanged, you must specify that key.
-func MakeAssetConfigTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
+func MakeAssetConfigTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
 	index uint64, newManager, newReserve, newFreeze, newClawback string) (types.Transaction, error) {
-	tx, err := MakeAssetConfigTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash, lease,
+	tx, err := MakeAssetConfigTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash,
 		index, newManager, newReserve, newFreeze, newClawback)
 	if err != nil {
 		return types.Transaction{}, err
@@ -657,12 +640,11 @@ func MakeAssetConfigTxnWithFlatFee(account string, fee, firstRound, lastRound ui
 // - lastRound is the last round this txn is valid
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
-// - lease - for information on leases, see types/transaction.go
 // - index is the asset index
 func MakeAssetTransferTxnWithFlatFee(account, recipient, closeAssetsTo string, amount, fee, firstRound, lastRound uint64, note []byte,
-	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
+	genesisID, genesisHash string, index uint64) (types.Transaction, error) {
 	tx, err := MakeAssetTransferTxn(account, recipient, closeAssetsTo, amount,
-		fee, firstRound, lastRound, note, genesisID, genesisHash, lease, index)
+		fee, firstRound, lastRound, note, genesisID, genesisHash, index)
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -682,12 +664,11 @@ func MakeAssetTransferTxnWithFlatFee(account, recipient, closeAssetsTo string, a
 // - lastRound is the last round this txn is valid
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
-// - lease - for information on leases, see types/transaction.go
 // - index is the asset index
 func MakeAssetAcceptanceTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte,
-	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
+	genesisID, genesisHash string, index uint64) (types.Transaction, error) {
 	tx, err := MakeAssetTransferTxnWithFlatFee(account, account, "", 0,
-		fee, firstRound, lastRound, note, genesisID, genesisHash, lease, index)
+		fee, firstRound, lastRound, note, genesisID, genesisHash, index)
 	return tx, err
 }
 
@@ -701,12 +682,11 @@ func MakeAssetAcceptanceTxnWithFlatFee(account string, fee, firstRound, lastRoun
 // - note is an arbitrary byte array
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
-// - lease - for information on leases, see types/transaction.go
 // - index is the asset index
 func MakeAssetRevocationTxnWithFlatFee(account, target, recipient string, amount, fee, firstRound, lastRound uint64, note []byte,
-	genesisID, genesisHash string, lease [32]byte, index uint64) (types.Transaction, error) {
+	genesisID, genesisHash, creator string, index uint64) (types.Transaction, error) {
 	tx, err := MakeAssetRevocationTxn(account, target, recipient, amount, fee, firstRound, lastRound,
-		note, genesisID, genesisHash, lease, index)
+		note, genesisID, genesisHash, index)
 
 	if err != nil {
 		return types.Transaction{}, err
@@ -728,19 +708,18 @@ func MakeAssetRevocationTxnWithFlatFee(account, target, recipient string, amount
 // - lastRound is the last round this txn is valid
 // - genesis id corresponds to the id of the network
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
-// - lease - for information on leases, see types/transaction.go
 // - index is the asset index
-func MakeAssetDestroyTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
+func MakeAssetDestroyTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
 	creator string, index uint64) (types.Transaction, error) {
-	tx, err := MakeAssetConfigTxnWithFlatFee(account, fee, firstRound, lastRound, note, genesisID, genesisHash, lease,
+	tx, err := MakeAssetConfigTxnWithFlatFee(account, fee, firstRound, lastRound, note, genesisID, genesisHash,
 		index, "", "", "", "")
 	return tx, err
 }
 
 // MakeAssetFreezeTxnWithFlatFee is as MakeAssetFreezeTxn, but taking a flat fee rather than a fee per byte.
-func MakeAssetFreezeTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, lease [32]byte,
+func MakeAssetFreezeTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
 	creator string, assetIndex uint64, target string, newFreezeSetting bool) (types.Transaction, error) {
-	tx, err := MakeAssetFreezeTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash, lease,
+	tx, err := MakeAssetFreezeTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash,
 		assetIndex, target, newFreezeSetting)
 	if err != nil {
 		return types.Transaction{}, err

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -757,42 +757,6 @@ func AssignGroupID(txns []types.Transaction, account string) (result []types.Tra
 	return result, nil
 }
 
-// AddLease adds the passed lease (see types/transaction.go) to the header of the passed transaction
-// - txn: the types.Transaction to modify
-// - lease: the [32]byte lease to add to the header
-// - feePerByte: the new feePerByte
-func AddLease(tx types.Transaction, lease [32]byte, feePerByte uint64) (types.Transaction, error) {
-	tx.Header.Lease = lease
-	tx.Header.Fee = types.MicroAlgos(feePerByte)
-	// Update fee
-	eSize, err := estimateSize(tx)
-	if err != nil {
-		return types.Transaction{}, err
-	}
-	tx.Fee = types.MicroAlgos(eSize * feePerByte)
-
-	if tx.Fee < MinTxnFee {
-		tx.Fee = MinTxnFee
-	}
-	return tx, nil
-}
-
-// AddLeaseWithFlatFee adds the passed lease (see types/transaction.go) to the header of the passed transaction
-// - txn: the types.Transaction to modify
-// - lease: the [32]byte lease to add to the header
-// - feePerByte: the new feePerByte
-func AddLeaseWithFlatFee(tx types.Transaction, lease [32]byte, flatFee uint64) (types.Transaction, error) {
-	tx.Header.Lease = lease
-	tx.Header.Fee = 0
-	// Update fee
-	tx.Fee = types.MicroAlgos(flatFee)
-
-	if tx.Fee < MinTxnFee {
-		tx.Fee = MinTxnFee
-	}
-	return tx, nil
-}
-
 // EstimateSize returns the estimated length of the encoded transaction
 func estimateSize(txn types.Transaction) (uint64, error) {
 	key := crypto.GenerateAccount()

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -64,7 +64,7 @@ func MakePaymentTxn(from, to string, fee, amount, firstRound, lastRound uint64, 
 	}
 
 	// Update fee
-	eSize, err := tx.EstimateSize()
+	eSize, err := estimateSize(tx)
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -152,7 +152,7 @@ func MakeKeyRegTxn(account string, feePerByte, firstRound, lastRound uint64, not
 	}
 
 	// Update fee
-	eSize, err := tx.EstimateSize()
+	eSize, err := estimateSize(tx)
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -285,7 +285,7 @@ func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64
 	}
 
 	// Update fee
-	eSize, err := tx.EstimateSize()
+	eSize, err := estimateSize(tx)
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -372,7 +372,7 @@ func MakeAssetConfigTxn(account string, feePerByte, firstRound, lastRound uint64
 	}
 
 	// Update fee
-	eSize, err := tx.EstimateSize()
+	eSize, err := estimateSize(tx)
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -439,7 +439,7 @@ func transferAssetBuilder(account, recipient, closeAssetsTo, revocationTarget st
 	tx.AssetAmount = amount
 
 	// Update fee
-	eSize, err := tx.EstimateSize()
+	eSize, err := estimateSize(tx)
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -570,7 +570,7 @@ func MakeAssetFreezeTxn(account string, fee, firstRound, lastRound uint64, note 
 
 	tx.AssetFrozen = newFreezeSetting
 	// Update fee
-	eSize, err := tx.EstimateSize()
+	eSize, err := estimateSize(tx)
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -765,7 +765,7 @@ func AddLease(tx types.Transaction, lease [32]byte, feePerByte uint64) (types.Tr
 	tx.Header.Lease = lease
 	tx.Header.Fee = types.MicroAlgos(feePerByte)
 	// Update fee
-	eSize, err := tx.EstimateSize()
+	eSize, err := estimateSize(tx)
 	if err != nil {
 		return types.Transaction{}, err
 	}
@@ -791,6 +791,16 @@ func AddLeaseWithFlatFee(tx types.Transaction, lease [32]byte, flatFee uint64) (
 		tx.Fee = MinTxnFee
 	}
 	return tx, nil
+}
+
+// EstimateSize returns the estimated length of the encoded transaction
+func estimateSize(txn types.Transaction) (uint64, error) {
+	key := crypto.GenerateAccount()
+	_, stx, err := crypto.SignTransaction(key.PrivateKey, txn)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(len(stx)), nil
 }
 
 // byte32FromBase64 decodes the input base64 string and outputs a

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -34,7 +34,7 @@ func TestMakePaymentTxn(t *testing.T) {
 	const golden = "gqNzaWfEQPhUAZ3xkDDcc8FvOVo6UinzmKBCqs0woYSfodlmBMfQvGbeUx3Srxy3dyJDzv7rLm26BRv9FnL2/AuT7NYfiAWjdHhui6NhbXTNA+ilY2xvc2XEIEDpNJKIJWTLzpxZpptnVCaJ6aHDoqnqW2Wm6KRCH/xXo2ZlZc0EmKJmds0wsqNnZW6sZGV2bmV0LXYzMy4womdoxCAmCyAJoJOohot5WHIvpeVG7eftF+TYXEx4r7BFJpDt0qJsds00mqRub3RlxAjqABVHQ2y/lqNyY3bEIHts4k/rW6zAsWTinCIsV/X2PcOH1DkEglhBHF/hD3wCo3NuZMQg5/D4TQaBHfnzHI2HixFV9GcdUaGFwgCQhmf0SVhwaKGkdHlwZaNwYXk="
 	gh := byteFromBase64("JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=")
 
-	txn, err := MakePaymentTxn(fromAddress, toAddress, 4, 1000, 12466, 13466, byteFromBase64("6gAVR0Nsv5Y="), "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA", "devnet-v33.0", gh, [32]byte{})
+	txn, err := MakePaymentTxn(fromAddress, toAddress, 4, 1000, 12466, 13466, byteFromBase64("6gAVR0Nsv5Y="), "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA", "devnet-v33.0", gh)
 	require.NoError(t, err)
 
 	key, err := mnemonic.ToPrivateKey(mn)
@@ -48,37 +48,14 @@ func TestMakePaymentTxn(t *testing.T) {
 	require.Equal(t, referenceTxID, id)
 }
 
-// should fail on a lack of GenesisH[32]byte{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}ash
+// should fail on a lack of GenesisHash
 func TestMakePaymentTxn2(t *testing.T) {
 	const fromAddress = "47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU"
 	const toAddress = "PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI"
 
-	_, err := MakePaymentTxn(fromAddress, toAddress, 4, 1000, 12466, 13466, byteFromBase64("6gAVR0Nsv5Y="), "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA", "devnet-v33.0", []byte{}, [32]byte{})
+	_, err := MakePaymentTxn(fromAddress, toAddress, 4, 1000, 12466, 13466, byteFromBase64("6gAVR0Nsv5Y="), "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA", "devnet-v33.0", []byte{})
 	require.Error(t, err)
 
-}
-
-func TestMakePaymentTxnWithLease(t *testing.T) {
-	const fromAddress = "47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU"
-	const toAddress = "PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI"
-	const referenceTxID = "7BG6COBZKF6I6W5XY72ZE4HXV6LLZ6ENSR6DASEGSTXYXR4XJOOQ"
-	const mn = "advice pudding treat near rule blouse same whisper inner electric quit surface sunny dismiss leader blood seat clown cost exist hospital century reform able sponsor"
-	const golden = "gqNzaWfEQOMmFSIKsZvpW0txwzhmbgQjxv6IyN7BbV5sZ2aNgFbVcrWUnqPpQQxfPhV/wdu9jzEPUU1jAujYtcNCxJ7ONgejdHhujKNhbXTNA+ilY2xvc2XEIEDpNJKIJWTLzpxZpptnVCaJ6aHDoqnqW2Wm6KRCH/xXo2ZlZc0FLKJmds0wsqNnZW6sZGV2bmV0LXYzMy4womdoxCAmCyAJoJOohot5WHIvpeVG7eftF+TYXEx4r7BFJpDt0qJsds00mqJseMQgAQIDBAECAwQBAgMEAQIDBAECAwQBAgMEAQIDBAECAwSkbm90ZcQI6gAVR0Nsv5ajcmN2xCB7bOJP61uswLFk4pwiLFf19j3Dh9Q5BIJYQRxf4Q98AqNzbmTEIOfw+E0GgR358xyNh4sRVfRnHVGhhcIAkIZn9ElYcGihpHR5cGWjcGF5"
-	gh := byteFromBase64("JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=")
-
-	lease := [32]byte{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}
-	txn, err := MakePaymentTxn(fromAddress, toAddress, 4, 1000, 12466, 13466, byteFromBase64("6gAVR0Nsv5Y="), "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA", "devnet-v33.0", gh, lease)
-	require.NoError(t, err)
-
-	key, err := mnemonic.ToPrivateKey(mn)
-	require.NoError(t, err)
-
-	id, bytes, err := crypto.SignTransaction(key, txn)
-
-	stxBytes := byteFromBase64(golden)
-	require.Equal(t, stxBytes, bytes)
-
-	require.Equal(t, referenceTxID, id)
 }
 
 func TestKeyRegTxn(t *testing.T) {
@@ -117,7 +94,7 @@ func TestKeyRegTxn(t *testing.T) {
 
 func TestMakeKeyRegTxn(t *testing.T) {
 	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
-	tx, err := MakeKeyRegTxn(addr, 10, 322575, 323575, []byte{45, 67}, "", "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=", [32]byte{},
+	tx, err := MakeKeyRegTxn(addr, 10, 322575, 323575, []byte{45, 67}, "", "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
 		"Kv7QI7chi1y6axoy+t7wzAVpePqRq/rkjzWh/RMYyLo=", "bPgrv4YogPcdaUAxrt1QysYZTVyRAuUMD4zQmCu9llc=", 10000, 10111, 11)
 	require.NoError(t, err)
 
@@ -157,7 +134,7 @@ func TestMakeAssetCreateTxn(t *testing.T) {
 	const assetName = "testcoin"
 	const testURL = "website"
 	const metadataHash = "fACPO4nRgO55j1ndAK3W6Sgc4APkcyFh"
-	tx, err := MakeAssetCreateTxn(addr, 10, 322575, 323575, nil, "", genesisHash, [32]byte{},
+	tx, err := MakeAssetCreateTxn(addr, 10, 322575, 323575, nil, "", genesisHash,
 		total, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName, testURL, metadataHash)
 	require.NoError(t, err)
 
@@ -204,7 +181,7 @@ func TestMakeAssetConfigTxn(t *testing.T) {
 	const freeze = addr
 	const clawback = addr
 	const assetIndex = 1234
-	tx, err := MakeAssetConfigTxn(addr, 10, 322575, 323575, nil, "", genesisHash, [32]byte{},
+	tx, err := MakeAssetConfigTxn(addr, 10, 322575, 323575, nil, "", genesisHash,
 		assetIndex, manager, reserve, freeze, clawback)
 	require.NoError(t, err)
 
@@ -246,7 +223,7 @@ func TestMakeAssetDestroyTxn(t *testing.T) {
 	const assetIndex = 1
 	const firstValidRound = 322575
 	const lastValidRound = 323575
-	tx, err := MakeAssetDestroyTxn(creator, 10, firstValidRound, lastValidRound, nil, "", genesisHash, [32]byte{}, assetIndex)
+	tx, err := MakeAssetDestroyTxn(creator, 10, firstValidRound, lastValidRound, nil, "", genesisHash, assetIndex)
 	require.NoError(t, err)
 
 	a, err := types.DecodeAddress(creator)
@@ -283,7 +260,7 @@ func TestMakeAssetFreezeTxn(t *testing.T) {
 	const lastValidRound = 323576
 	const freezeSetting = true
 	const target = addr
-	tx, err := MakeAssetFreezeTxn(addr, 10, firstValidRound, lastValidRound, nil, "", genesisHash, [32]byte{}, assetIndex, target, freezeSetting)
+	tx, err := MakeAssetFreezeTxn(addr, 10, firstValidRound, lastValidRound, nil, "", genesisHash, assetIndex, target, freezeSetting)
 	require.NoError(t, err)
 
 	a, err := types.DecodeAddress(addr)
@@ -327,7 +304,7 @@ func TestMakeAssetTransferTxn(t *testing.T) {
 	const amountToSend = 1
 
 	tx, err := MakeAssetTransferTxn(sender, recipient, closeAssetsTo, amountToSend, 10, firstValidRound,
-		lastValidRound, nil, "", genesisHash, [32]byte{}, assetIndex)
+		lastValidRound, nil, "", genesisHash, assetIndex)
 	require.NoError(t, err)
 
 	sendAddr, err := types.DecodeAddress(sender)
@@ -375,7 +352,7 @@ func TestMakeAssetAcceptanceTxn(t *testing.T) {
 	const lastValidRound = 323575
 
 	tx, err := MakeAssetAcceptanceTxn(sender, 10, firstValidRound,
-		lastValidRound, nil, "", genesisHash, [32]byte{}, assetIndex)
+		lastValidRound, nil, "", genesisHash, assetIndex)
 	require.NoError(t, err)
 
 	sendAddr, err := types.DecodeAddress(sender)
@@ -418,7 +395,7 @@ func TestMakeAssetRevocationTransaction(t *testing.T) {
 	const amountToSend = 1
 
 	tx, err := MakeAssetRevocationTxn(revoker, revoked, recipient, amountToSend, 10, firstValidRound,
-		lastValidRound, nil, "", genesisHash, [32]byte{}, assetIndex)
+		lastValidRound, nil, "", genesisHash, assetIndex)
 	require.NoError(t, err)
 
 	sendAddr, err := types.DecodeAddress(revoker)
@@ -473,7 +450,7 @@ func TestComputeGroupID(t *testing.T) {
 	note1 := byteFromBase64("wRKw5cJ0CMo=")
 	tx1, err := MakePaymentTxnWithFlatFee(
 		fromAddress, toAddress, fee, amount, firstRound1, firstRound1+1000,
-		note1, "", genesisID, genesisHash, [32]byte{},
+		note1, "", genesisID, genesisHash,
 	)
 	require.NoError(t, err)
 
@@ -481,7 +458,7 @@ func TestComputeGroupID(t *testing.T) {
 	note2 := byteFromBase64("dBlHI6BdrIg=")
 	tx2, err := MakePaymentTxnWithFlatFee(
 		fromAddress, toAddress, fee, amount, firstRound2, firstRound2+1000,
-		note2, "", genesisID, genesisHash, [32]byte{},
+		note2, "", genesisID, genesisHash,
 	)
 	require.NoError(t, err)
 
@@ -538,7 +515,7 @@ func TestLogicSig(t *testing.T) {
 
 	tx, err := MakePaymentTxnWithFlatFee(
 		fromAddress, toAddress, fee, amount, firstRound, firstRound+1000,
-		note, "", genesisID, genesisHash, [32]byte{},
+		note, "", genesisID, genesisHash,
 	)
 	require.NoError(t, err)
 

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -58,6 +58,30 @@ func TestMakePaymentTxn2(t *testing.T) {
 
 }
 
+func TestMakePaymentTxnWithLease(t *testing.T) {
+	const fromAddress = "47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU"
+	const toAddress = "PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI"
+	const referenceTxID = "7BG6COBZKF6I6W5XY72ZE4HXV6LLZ6ENSR6DASEGSTXYXR4XJOOQ"
+	const mn = "advice pudding treat near rule blouse same whisper inner electric quit surface sunny dismiss leader blood seat clown cost exist hospital century reform able sponsor"
+	const golden = "gqNzaWfEQOMmFSIKsZvpW0txwzhmbgQjxv6IyN7BbV5sZ2aNgFbVcrWUnqPpQQxfPhV/wdu9jzEPUU1jAujYtcNCxJ7ONgejdHhujKNhbXTNA+ilY2xvc2XEIEDpNJKIJWTLzpxZpptnVCaJ6aHDoqnqW2Wm6KRCH/xXo2ZlZc0FLKJmds0wsqNnZW6sZGV2bmV0LXYzMy4womdoxCAmCyAJoJOohot5WHIvpeVG7eftF+TYXEx4r7BFJpDt0qJsds00mqJseMQgAQIDBAECAwQBAgMEAQIDBAECAwQBAgMEAQIDBAECAwSkbm90ZcQI6gAVR0Nsv5ajcmN2xCB7bOJP61uswLFk4pwiLFf19j3Dh9Q5BIJYQRxf4Q98AqNzbmTEIOfw+E0GgR358xyNh4sRVfRnHVGhhcIAkIZn9ElYcGihpHR5cGWjcGF5"
+	gh := byteFromBase64("JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=")
+
+	lease := [32]byte{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}
+	txn, err := MakePaymentTxn(fromAddress, toAddress, 4, 1000, 12466, 13466, byteFromBase64("6gAVR0Nsv5Y="), "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA", "devnet-v33.0", gh)
+	require.NoError(t, err)
+	txn, err = AddLease(txn, lease, 4)
+	require.NoError(t, err)
+
+	key, err := mnemonic.ToPrivateKey(mn)
+	require.NoError(t, err)
+
+	id, stxBytes, err := crypto.SignTransaction(key, txn)
+
+	goldenBytes := byteFromBase64(golden)
+	require.Equal(t, goldenBytes, stxBytes)
+	require.Equal(t, referenceTxID, id)
+}
+
 func TestKeyRegTxn(t *testing.T) {
 	// preKeyRegTxn is an unsigned signed keyreg txn with zero Sender
 	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -69,7 +69,7 @@ func TestMakePaymentTxnWithLease(t *testing.T) {
 	lease := [32]byte{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}
 	txn, err := MakePaymentTxn(fromAddress, toAddress, 4, 1000, 12466, 13466, byteFromBase64("6gAVR0Nsv5Y="), "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA", "devnet-v33.0", gh)
 	require.NoError(t, err)
-	txn, err = AddLease(txn, lease, 4)
+	txn.AddLease(lease, 4)
 	require.NoError(t, err)
 
 	key, err := mnemonic.ToPrivateKey(mn)

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -1,10 +1,5 @@
 package types
 
-import (
-	"github.com/algorand/go-algorand-sdk/crypto"
-	"github.com/algorand/go-algorand-sdk/transaction"
-)
-
 // Transaction describes a transaction that can appear in a block.
 type Transaction struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
@@ -150,49 +145,4 @@ type TxGroup struct {
 	// valid.  Each hash in the list is a hash of a transaction with
 	// the `Group` field omitted.
 	TxGroupHashes []Digest `codec:"txlist"`
-}
-
-// EstimateSize returns the estimated length of the encoded transaction
-func (txn Transaction) EstimateSize() (uint64, error) {
-	key := crypto.GenerateAccount()
-	_, stx, err := crypto.SignTransaction(key.PrivateKey, txn)
-	if err != nil {
-		return 0, err
-	}
-	return uint64(len(stx)), nil
-}
-
-// AddLease adds the passed lease (see types/transaction.go) to the header of the passed transaction
-// - txn: the types.Transaction to modify
-// - lease: the [32]byte lease to add to the header
-// - feePerByte: the new feePerByte
-func (txn Transaction) AddLease(lease [32]byte, feePerByte uint64) error {
-	txn.Header.Lease = lease
-	txn.Header.Fee = MicroAlgos(feePerByte)
-	// Update fee
-	eSize, err := txn.EstimateSize()
-	if err != nil {
-		return err
-	}
-	txn.Fee = MicroAlgos(eSize * feePerByte)
-
-	if txn.Fee < transaction.MinTxnFee {
-		txn.Fee = transaction.MinTxnFee
-	}
-	return nil
-}
-
-// AddLeaseWithFlatFee adds the passed lease (see types/transaction.go) to the header of the passed transaction
-// - txn: the types.Transaction to modify
-// - lease: the [32]byte lease to add to the header
-// - feePerByte: the new feePerByte
-func (txn Transaction) AddLeaseWithFlatFee(lease [32]byte, flatFee uint64) {
-	txn.Header.Lease = lease
-	txn.Header.Fee = 0
-	// Update fee
-	txn.Fee = MicroAlgos(flatFee)
-
-	if txn.Fee < transaction.MinTxnFee {
-		txn.Fee = transaction.MinTxnFee
-	}
 }

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -126,13 +126,6 @@ type Header struct {
 	// transaction group (and, if so, specifies the hash
 	// of a TxGroup).
 	Group Digest `codec:"grp"`
-
-	// Lease enforces mutual exclusion of transactions.  If this field is
-	// nonzero, then once the transaction is confirmed, it acquires the
-	// lease identified by the (Sender, Lease) pair of the transaction until
-	// the LastValid round passes.  While this transaction possesses the
-	// lease, no other transaction specifying this lease can be confirmed.
-	Lease [32]byte `codec:"lx"`
 }
 
 // TxGroup describes a group of transactions that must appear

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -146,3 +146,25 @@ type TxGroup struct {
 	// the `Group` field omitted.
 	TxGroupHashes []Digest `codec:"txlist"`
 }
+
+// AddLease adds the passed lease (see types/transaction.go) to the header of the passed transaction
+// and updates fee accordingly
+// - lease: the [32]byte lease to add to the header
+// - feePerByte: the new feePerByte
+func (tx *Transaction) AddLease(lease [32]byte, feePerByte uint64) {
+	copy(tx.Header.Lease[:], lease[:])
+	// normally we would use estimateSize,
+	// and set fee = feePerByte * estimateSize,
+	// but this would cause a circular import.
+	// we know we are adding 32 bytes (+ a few bytes to hold the 32), so increase fee accordingly.
+	tx.Header.Fee = tx.Header.Fee + MicroAlgos(37*feePerByte)
+}
+
+// AddLeaseWithFlatFee adds the passed lease (see types/transaction.go) to the header of the passed transaction
+// and updates fee accordingly
+// - lease: the [32]byte lease to add to the header
+// - flatFee: the new flatFee
+func (tx *Transaction) AddLeaseWithFlatFee(lease [32]byte, flatFee uint64) {
+	tx.Header.Lease = lease
+	tx.Header.Fee = MicroAlgos(flatFee)
+}

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -1,5 +1,10 @@
 package types
 
+import (
+	"github.com/algorand/go-algorand-sdk/crypto"
+	"github.com/algorand/go-algorand-sdk/transaction"
+)
+
 // Transaction describes a transaction that can appear in a block.
 type Transaction struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
@@ -145,4 +150,49 @@ type TxGroup struct {
 	// valid.  Each hash in the list is a hash of a transaction with
 	// the `Group` field omitted.
 	TxGroupHashes []Digest `codec:"txlist"`
+}
+
+// EstimateSize returns the estimated length of the encoded transaction
+func (txn Transaction) EstimateSize() (uint64, error) {
+	key := crypto.GenerateAccount()
+	_, stx, err := crypto.SignTransaction(key.PrivateKey, txn)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(len(stx)), nil
+}
+
+// AddLease adds the passed lease (see types/transaction.go) to the header of the passed transaction
+// - txn: the types.Transaction to modify
+// - lease: the [32]byte lease to add to the header
+// - feePerByte: the new feePerByte
+func (txn Transaction) AddLease(lease [32]byte, feePerByte uint64) error {
+	txn.Header.Lease = lease
+	txn.Header.Fee = MicroAlgos(feePerByte)
+	// Update fee
+	eSize, err := txn.EstimateSize()
+	if err != nil {
+		return err
+	}
+	txn.Fee = MicroAlgos(eSize * feePerByte)
+
+	if txn.Fee < transaction.MinTxnFee {
+		txn.Fee = transaction.MinTxnFee
+	}
+	return nil
+}
+
+// AddLeaseWithFlatFee adds the passed lease (see types/transaction.go) to the header of the passed transaction
+// - txn: the types.Transaction to modify
+// - lease: the [32]byte lease to add to the header
+// - feePerByte: the new feePerByte
+func (txn Transaction) AddLeaseWithFlatFee(lease [32]byte, flatFee uint64) {
+	txn.Header.Lease = lease
+	txn.Header.Fee = 0
+	// Update fee
+	txn.Fee = MicroAlgos(flatFee)
+
+	if txn.Fee < transaction.MinTxnFee {
+		txn.Fee = transaction.MinTxnFee
+	}
 }

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -126,6 +126,13 @@ type Header struct {
 	// transaction group (and, if so, specifies the hash
 	// of a TxGroup).
 	Group Digest `codec:"grp"`
+
+	// Lease enforces mutual exclusion of transactions.  If this field is
+	// nonzero, then once the transaction is confirmed, it acquires the
+	// lease identified by the (Sender, Lease) pair of the transaction until
+	// the LastValid round passes.  While this transaction possesses the
+	// lease, no other transaction specifying this lease can be confirmed.
+	Lease [32]byte `codec:"lx"`
 }
 
 // TxGroup describes a group of transactions that must appear


### PR DESCRIPTION
## Summary
Previous lease implementation broke backwards compatibility. Now, `AddLease` is used to add a lease to an existing transaction.

### Testing
Golden still passes.

### See also
https://github.com/algorand/go-algorand-sdk/issues/79