### PR TITLE
Add asset decimals field

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,7 @@ fee := uint64(10) // the number of microAlgos per byte to pay as a transaction f
 defaultFrozen := false // whether user accounts will need to be unfrozen before transacting
 genesisHash := "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=" // hash of the genesis block of the network to be used
 totalIssuance := uint64(100) // total number of this asset in circulation
+decimals := uint64(1) // hint to GUIs for interpreting base unit
 reserve := addr // specified address is considered the asset reserve (it has no special privileges, this is only informational)
 freeze := addr // specified address can freeze or unfreeze user asset holdings
 clawback := addr // specified address can revoke user asset holdings and send them to other addresses
@@ -812,7 +813,7 @@ assetMetadataHash := "thisIsSomeLength32HashCommitment" // optional hash commitm
 
 // signing and sending "txn" allows "addr" to create an asset
 txn, err = MakeAssetCreateTxn(addr, fee, firstRound, lastRound, note,
-    genesisID, genesisHash, totalIssuance, defaultFrozen, manager, reserve, freeze, clawback,
+    genesisID, genesisHash, totalIssuance, decimals, defaultFrozen, manager, reserve, freeze, clawback,
     unitName, assetName, assetURL, assetMetadataHash)
 ```
 

--- a/client/algod/models/models.go
+++ b/client/algod/models/models.go
@@ -127,6 +127,14 @@ type AssetParams struct {
 	// required: true
 	Total uint64 `json:"total"`
 
+	// Decimals specifies the number of digits to use after the decimal
+	// point when displaying this asset. If 0, the asset is not divisible.
+	// If 1, the base unit of the asset is in tenths. If 2, the base unit
+	// of the asset is in hundredths, and so on.
+	//
+	// required: true
+	Decimals uint32 `json:"decimals"`
+
 	// DefaultFrozen specifies whether holdings in this asset
 	// are frozen by default.
 	//

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -205,15 +205,14 @@ func MakeKeyRegTxnWithFlatFee(account string, fee, firstRound, lastRound uint64,
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // Asset creation parameters:
 // - see asset.go
-func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
-	total uint64, defaultFrozen bool, manager, reserve, freeze, clawback string,
-	unitName, assetName, url, metadataHash string) (types.Transaction, error) {
+func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, total uint64, decimals uint32, defaultFrozen bool, manager, reserve, freeze, clawback string, unitName, assetName, url, metadataHash string) (types.Transaction, error) {
 	var tx types.Transaction
 	var err error
 
 	tx.Type = types.AssetConfigTx
 	tx.AssetParams = types.AssetParams{
 		Total:         total,
+		Decimals:      decimals,
 		DefaultFrozen: defaultFrozen,
 		UnitName:      unitName,
 		AssetName:     assetName,
@@ -598,9 +597,8 @@ func MakeAssetFreezeTxn(account string, fee, firstRound, lastRound uint64, note 
 // Asset creation parameters:
 // - see asset.go
 func MakeAssetCreateTxnWithFlatFee(account string, fee, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
-	total uint64, defaultFrozen bool, manager, reserve, freeze, clawback, unitName, assetName, url, metadataHash string) (types.Transaction, error) {
-	tx, err := MakeAssetCreateTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash,
-		total, defaultFrozen, manager, reserve, freeze, clawback, unitName, assetName, url, metadataHash)
+	total uint64, decimals uint32, defaultFrozen bool, manager, reserve, freeze, clawback, unitName, assetName, url, metadataHash string) (types.Transaction, error) {
+	tx, err := MakeAssetCreateTxn(account, fee, firstRound, lastRound, note, genesisID, genesisHash, total, decimals, defaultFrozen, manager, reserve, freeze, clawback, unitName, assetName, url, metadataHash)
 	if err != nil {
 		return types.Transaction{}, err
 	}

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -211,6 +211,10 @@ func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64
 	var tx types.Transaction
 	var err error
 
+	if decimals > types.AssetMaxNumberOfDecimals {
+		return tx, fmt.Errorf("cannot create an asset with number of decimals %d (more than maximum %d)", decimals, types.AssetMaxNumberOfDecimals)
+	}
+
 	tx.Type = types.AssetConfigTx
 	tx.AssetParams = types.AssetParams{
 		Total:         total,

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -205,7 +205,9 @@ func MakeKeyRegTxnWithFlatFee(account string, fee, firstRound, lastRound uint64,
 // - genesis hash corresponds to the base64-encoded hash of the genesis of the network
 // Asset creation parameters:
 // - see asset.go
-func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string, total uint64, decimals uint32, defaultFrozen bool, manager, reserve, freeze, clawback string, unitName, assetName, url, metadataHash string) (types.Transaction, error) {
+func MakeAssetCreateTxn(account string, feePerByte, firstRound, lastRound uint64, note []byte, genesisID, genesisHash string,
+	total uint64, decimals uint32, defaultFrozen bool, manager, reserve, freeze, clawback string,
+	unitName, assetName, url, metadataHash string) (types.Transaction, error) {
 	var tx types.Transaction
 	var err error
 

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -196,6 +196,58 @@ func TestMakeAssetCreateTxn(t *testing.T) {
 	require.EqualValues(t, newStxBytes, byteFromBase64(signedGolden))
 }
 
+func TestMakeAssetCreateTxnWithDecimals(t *testing.T) {
+	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
+	const defaultFrozen = false
+	const genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="
+	const total = 100
+	const decimals = 1
+	const reserve = addr
+	const freeze = addr
+	const clawback = addr
+	const unitName = "tst"
+	const assetName = "testcoin"
+	const testURL = "website"
+	const metadataHash = "fACPO4nRgO55j1ndAK3W6Sgc4APkcyFh"
+	tx, err := MakeAssetCreateTxn(addr, 10, 322575, 323575, nil, "", genesisHash, total, decimals, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName, testURL, metadataHash)
+	require.NoError(t, err)
+
+	a, err := types.DecodeAddress(addr)
+	require.NoError(t, err)
+	expectedAssetCreationTxn := types.Transaction{
+		Type: types.AssetConfigTx,
+		Header: types.Header{
+			Sender:      a,
+			Fee:         4060,
+			FirstValid:  322575,
+			LastValid:   323575,
+			GenesisHash: byte32ArrayFromBase64(genesisHash),
+			GenesisID:   "",
+		},
+	}
+	expectedAssetCreationTxn.AssetParams = types.AssetParams{
+		Total:         total,
+		Decimals:      decimals,
+		DefaultFrozen: defaultFrozen,
+		Manager:       a,
+		Reserve:       a,
+		Freeze:        a,
+		Clawback:      a,
+		UnitName:      unitName,
+		AssetName:     assetName,
+		URL:           testURL,
+	}
+	copy(expectedAssetCreationTxn.AssetParams.MetadataHash[:], []byte(metadataHash))
+	require.Equal(t, expectedAssetCreationTxn, tx)
+
+	const addrSK = "awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred"
+	private, err := mnemonic.ToPrivateKey(addrSK)
+	require.NoError(t, err)
+	_, newStxBytes, err := crypto.SignTransaction(private, tx)
+	signedGolden := "gqNzaWfEQCj5xLqNozR5ahB+LNBlTG+d0gl0vWBrGdAXj1ibsCkvAwOsXs5KHZK1YdLgkdJecQiWm4oiZ+pm5Yg0m3KFqgqjdHhuh6RhcGFyiqJhbcQgZkFDUE80blJnTzU1ajFuZEFLM1c2U2djNEFQa2N5RmiiYW6odGVzdGNvaW6iYXWnd2Vic2l0ZaFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aJkYwGhZsQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2hbcQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2hcsQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2hdGSidW6jdHN0o2ZlZc0P3KJmds4ABOwPomdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJsds4ABO/3o3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2kdHlwZaRhY2Zn"
+	require.EqualValues(t, newStxBytes, byteFromBase64(signedGolden))
+}
+
 func TestMakeAssetConfigTxn(t *testing.T) {
 	const addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
 	const genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -158,8 +158,7 @@ func TestMakeAssetCreateTxn(t *testing.T) {
 	const assetName = "testcoin"
 	const testURL = "website"
 	const metadataHash = "fACPO4nRgO55j1ndAK3W6Sgc4APkcyFh"
-	tx, err := MakeAssetCreateTxn(addr, 10, 322575, 323575, nil, "", genesisHash,
-		total, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName, testURL, metadataHash)
+	tx, err := MakeAssetCreateTxn(addr, 10, 322575, 323575, nil, "", genesisHash, total, 0, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName, testURL, metadataHash)
 	require.NoError(t, err)
 
 	a, err := types.DecodeAddress(addr)

--- a/types/asset.go
+++ b/types/asset.go
@@ -24,6 +24,13 @@ type AssetParams struct {
 	// created.
 	Total uint64 `codec:"t"`
 
+	// Decimals specifies the number of digits to display after the decimal
+	// place when displaying this asset. A value of 0 represents an asset
+	// that is not divisible, a value of 1 represents an asset divisible
+	// into tenths, and so on. This value must be between 0 and 19
+	// (inclusive).
+	Decimals uint32 `codec:"dc"`
+
 	// DefaultFrozen specifies whether slots for this asset
 	// in user accounts are frozen by default or not.
 	DefaultFrozen bool `codec:"df"`

--- a/types/asset.go
+++ b/types/asset.go
@@ -12,6 +12,9 @@ const AssetURLMaxLen = 32
 // AssetMetadataHashLen is the length of the AssetMetadataHash in bytes
 const AssetMetadataHashLen = 32
 
+// AssetMaxNumberOfDecimals is the maximum value of the Decimals field
+const AssetMaxNumberOfDecimals = 19
+
 // AssetIndex is the unique integer index of an asset that can be used to look
 // up the creator of the asset, whose balance record contains the AssetParams
 type AssetIndex uint64


### PR DESCRIPTION
Add a decimals/precision field to asset creation.

### Testing
Automatic unit testing. `algorand-sdk-testing` will fail due to signature mismatch, see pull 30 in "See also" section.

### See also
https://github.com/algorand/go-algorand/pull/601
https://github.com/algorand/algorand-sdk-testing/pull/30
https://github.com/algorand/go-algorand-sdk/issues/97