### PR TITLE
Limit order TEAL template

### DIFF
--- a/templates/hashTimeLockedContract.go
+++ b/templates/hashTimeLockedContract.go
@@ -12,7 +12,7 @@ type HTLC struct {
 	ContractTemplate
 }
 
-// MakeHTLC allows a user to recieve the Algo prior to a deadline (in terms of a round) by proving a knowledge
+// MakeHTLC allows a user to receive the Algo prior to a deadline (in terms of a round) by proving a knowledge
 // of a special value or to forfeit the ability to claim, returning it to the payer.
 // This contract is usually used to perform cross-chained atomic swaps
 //
@@ -22,8 +22,7 @@ type HTLC struct {
 // 2. To owner if txn.FirstValid > expiry_round
 // ...
 //
-//Parameters
-//----------
+// Parameters:
 // - owner : string an address that can receive the asset after the expiry round
 // - receiver: string address to receive Algos
 // - hashFunction : string the hash function to be used (must be either sha256 or keccak256)

--- a/templates/limitOrder.go
+++ b/templates/limitOrder.go
@@ -18,9 +18,14 @@ type LimitOrder struct {
 // assetAmount: amount of assets to be sent
 // contract: byteform of the contract from the payer
 // secretKey: secret key for signing transactions
+// fee: fee per byte used for the transactions
+// algoAmount: number of algos to transfer
+// firstRound: first round on which these txns will be valid
+// lastRound: last round on which these txns will be valid
+// genesisHash: genesisHash indicating the network for the txns
 // the first payment sends money (Algos) from contract to the recipient (we'll call him Buyer), closing the rest of the account to Owner
 // the second payment sends money (the asset) from Buyer to the Owner
-// these transactions will be rejected if they do not meet or beat the ratio set at contract creation
+// these transactions will be rejected if they do not meet the restrictions set by the contract
 func (lo LimitOrder) GetSwapAssetsTransaction(assetAmount uint64, contract, secretKey []byte, fee, algoAmount, firstRound, lastRound uint64, genesisHash []byte) ([]byte, error) {
 	var buyerAddress types.Address
 	copy(buyerAddress[:], secretKey[32:])

--- a/templates/limitOrder.go
+++ b/templates/limitOrder.go
@@ -66,8 +66,8 @@ func (lo LimitOrder) GetSwapAssetsTransaction(assetAmount uint64, contract, secr
 	return signedGroup, nil
 }
 
-// MakeLimitOrder
-// Works on a contract account.
+// MakeLimitOrder allows a user to exchange some number of N assets for D algos.
+// This is a contract account.
 // Fund the contract with some number of Algos to limit the maximum number of
 // Algos you're willing to trade for some other asset.
 //

--- a/templates/limitOrder.go
+++ b/templates/limitOrder.go
@@ -66,8 +66,7 @@ func (lo LimitOrder) GetSwapAssetsTransaction(assetAmount uint64, contract, secr
 	return signedGroup, nil
 }
 
-// MakeLimitOrder allows a user to exchange some number of N assets for D algos.
-// This is a contract account.
+// MakeLimitOrder allows a user to exchange some number of assets for some number of algos.
 // Fund the contract with some number of Algos to limit the maximum number of
 // Algos you're willing to trade for some other asset.
 //

--- a/templates/limitOrder.go
+++ b/templates/limitOrder.go
@@ -9,8 +9,6 @@ import (
 // Split template representation
 type LimitOrder struct {
 	ContractTemplate
-	ratn uint64
-	ratd uint64
 }
 
 // GetSwapAssetsTransaction returns a group transaction array which transfer funds according to the contract's ratio
@@ -64,12 +62,12 @@ func MakeLimitOrder(owner string, assetID, ratn, ratd, expiryRound, minTrade, ma
 		return LimitOrder{}, err
 	}
 
-	var referenceOffsets = []uint64{ /*fee*/ 4 /*timeout*/, 7 /*ratn*/, 8 /*ratd*/, 9 /*minPay*/, 10 /*owner*/, 14 /*receiver1*/, 47 /*receiver2*/, 80}
+	var referenceOffsets = []uint64{ /*maxFee*/ 5 /*minTrade*/, 7 /*assetID*/, 9 /*ratd*/, 10 /*ratn*/, 11 /*expiryRound*/, 12 /*ownerAddr*/, 16}
 	ownerAddr, err := types.DecodeAddress(owner)
 	if err != nil {
 		return LimitOrder{}, err
 	}
-	injectionVector := []interface{}{maxFee, expiryRound, ratn, ratd, minTrade, ownerAddr}
+	injectionVector := []interface{}{maxFee, minTrade, assetID, ratd, ratn, expiryRound, ownerAddr}
 	injectedBytes, err := inject(referenceAsBytes, referenceOffsets, injectionVector)
 	if err != nil {
 		return LimitOrder{}, err
@@ -81,8 +79,6 @@ func MakeLimitOrder(owner string, assetID, ratn, ratd, expiryRound, minTrade, ma
 			address: address.String(),
 			program: injectedBytes,
 		},
-		ratn: ratn,
-		ratd: ratd,
 	}
 	return lo, err
 }

--- a/templates/limitOrder.go
+++ b/templates/limitOrder.go
@@ -1,0 +1,88 @@
+package templates
+
+import (
+	"encoding/base64"
+	"github.com/algorand/go-algorand-sdk/crypto"
+	"github.com/algorand/go-algorand-sdk/types"
+)
+
+// Split template representation
+type LimitOrder struct {
+	ContractTemplate
+	ratn uint64
+	ratd uint64
+}
+
+// GetSwapAssetsTransaction returns a group transaction array which transfer funds according to the contract's ratio
+// amount: amount of assets to be sent
+// contract: byteform of the contract from the payer
+// secretKey: secret key for signing transactions
+func GetSwapAssetsTransaction() ([]byte, error) {
+
+	var stx1 []byte
+	var stx2 []byte
+	var signedGroup []byte
+	signedGroup = append(signedGroup, stx1...)
+	signedGroup = append(signedGroup, stx2...)
+
+	return signedGroup, nil
+}
+
+// MakeLimitOrder
+// Works on a contract account.
+// Fund the contract with some number of Algos to limit the maximum number of
+// Algos you're willing to trade for some other asset.
+//
+// Works on two cases:
+// * trading Algos for some other asset
+// * closing out Algos back to the originator after a timeout
+//
+// trade case, a 2 transaction group:
+// gtxn[0] (this txn) Algos from Me to Other
+// gtxn[1] asset from Other to Me
+//
+// We want to get _at least_ some amount of the other asset per our Algos
+// gtxn[1].AssetAmount / gtxn[0].Amount >= N / D
+// ===
+// gtxn[1].AssetAmount * D >= gtxn[0].Amount * N
+//
+// close-out case:
+// txn alone, close out value after timeout
+//
+// Parameters:
+//  - owner: the address to refund funds to on timeout
+//  - assetID: ID of the transferred asset
+//  - ratn: exchange rate (N asset per D Algos, or better)
+//  - ratd: exchange rate (N asset per D Algos, or better)
+//  - expiryRound: the round at which the account expires
+//  - minTrade: the minimum amount (of Algos) to be traded away
+//  - maxFee: maximum fee used by the limit order transaction
+func MakeLimitOrder(owner string, assetID, ratn, ratd, expiryRound, minTrade, maxFee uint64) (LimitOrder, error) {
+	const referenceProgram = "ASAKAAEFAgYEBwgJCiYBIP68oLsUSlpOp7Q4pGgayA5soQW8tgf8VlMlyVaV9qITMRYiEjEQIxIQMQEkDhAyBCMSQABVMgQlEjEIIQQNEDEJMgMSEDMBECEFEhAzAREhBhIQMwEUKBIQMwETMgMSEDMBEiEHHTUCNQExCCEIHTUENQM0ATQDDUAAJDQBNAMSNAI0BA8QQAAWADEJKBIxAiEJDRAxBzIDEhAxCCISEBA="
+	referenceAsBytes, err := base64.StdEncoding.DecodeString(referenceProgram)
+	if err != nil {
+		return LimitOrder{}, err
+	}
+
+	var referenceOffsets = []uint64{ /*fee*/ 4 /*timeout*/, 7 /*ratn*/, 8 /*ratd*/, 9 /*minPay*/, 10 /*owner*/, 14 /*receiver1*/, 47 /*receiver2*/, 80}
+	ownerAddr, err := types.DecodeAddress(owner)
+	if err != nil {
+		return LimitOrder{}, err
+	}
+	injectionVector := []interface{}{maxFee, expiryRound, ratn, ratd, minTrade, ownerAddr}
+	injectedBytes, err := inject(referenceAsBytes, referenceOffsets, injectionVector)
+	if err != nil {
+		return LimitOrder{}, err
+	}
+
+	address := crypto.AddressFromProgram(injectedBytes)
+	lo := LimitOrder{
+		ContractTemplate: ContractTemplate{
+			address: address.String(),
+			program: injectedBytes,
+		},
+		ratn: ratn,
+		ratd: ratd,
+	}
+	return lo, err
+}

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -2,8 +2,6 @@ package templates
 
 import (
 	"encoding/base64"
-	"fmt"
-	"github.com/algorand/go-algorand-sdk/types"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -43,28 +41,18 @@ func TestHTLC(t *testing.T) {
 }
 
 func TestLimitOrder(t *testing.T) {
-	const referenceProgram = "ASAKAAEFAgYEBwgJCiYBIP68oLsUSlpOp7Q4pGgayA5soQW8tgf8VlMlyVaV9qITMRYiEjEQIxIQMQEkDhAyBCMSQABVMgQlEjEIIQQNEDEJMgMSEDMBECEFEhAzAREhBhIQMwEUKBIQMwETMgMSEDMBEiEHHTUCNQExCCEIHTUENQM0ATQDDUAAJDQBNAMSNAI0BA8QQAAWADEJKBIxAiEJDRAxBzIDEhAxCCISEBA="
-	referenceAsBytes, _ := base64.StdEncoding.DecodeString(referenceProgram)
-	addressToFind := "726KBOYUJJNE5J5UHCSGQGWIBZWKCBN4WYD7YVSTEXEVNFPWUIJ7TAEOPM"
-	addressBytes, _ := types.DecodeAddress(addressToFind)
-	for position, _ := range referenceAsBytes {
-		if addressBytes[0] == referenceAsBytes[position] && addressBytes[1] == referenceAsBytes[position+1] && addressBytes[2] == referenceAsBytes[position+2] {
-			fmt.Printf("found the address at position %d \n", position)
-		}
-	}
-
-	return
-	//// Inputs
-	//owner := "726KBOYUJJNE5J5UHCSGQGWIBZWKCBN4WYD7YVSTEXEVNFPWUIJ7TAEOPM"
-	//ratn, ratd := uint64(30), uint64(100) // for N algos, swap for (ratn/ratd)*N assets
-	//expiryRound := uint64(123456)
-	//minTrade := uint64(10000)
-	//maxFee := uint64(5000000)
-	//c, err := MakeLimitOrder(owner, ratn, ratd, expiryRound, minTrade, maxFee)
-	//// Outputs
-	//require.NoError(t, err)
-	//goldenProgram := "ASAIAcCWsQICAMDEBx5kkE4mAyCztwQn0+DycN+vsk+vJWcsoz/b7NDS6i33HOkvTpf+YiC3qUpIgHGWE8/1LPh9SGCalSN7IaITeeWSXbfsS5wsXyC4kBQ38Z8zcwWVAym4S8vpFB/c0XC6R4mnPi9EBADsPDEQIhIxASMMEDIEJBJAABkxCSgSMQcyAxIQMQglEhAxAiEEDRAiQAAuMwAAMwEAEjEJMgMSEDMABykSEDMBByoSEDMACCEFCzMBCCEGCxIQMwAIIQcPEBA="
-	//require.Equal(t, goldenProgram, base64.StdEncoding.EncodeToString(c.GetProgram()))
-	//goldenAddress := "KPYGWKTV7CKMPMTLQRNGMEQRSYTYDHUOFNV4UDSBDLC44CLIJPQWRTCPBU"
-	//require.Equal(t, goldenAddress, c.GetAddress())
+	// Inputs
+	owner := "726KBOYUJJNE5J5UHCSGQGWIBZWKCBN4WYD7YVSTEXEVNFPWUIJ7TAEOPM"
+	assetid := uint64(12345)
+	ratn, ratd := uint64(30), uint64(100) // for N algos, swap for (ratn/ratd)*N assets
+	expiryRound := uint64(123456)
+	minTrade := uint64(10000)
+	maxFee := uint64(5000000)
+	c, err := MakeLimitOrder(owner, assetid, ratn, ratd, expiryRound, minTrade, maxFee)
+	// Outputs
+	require.NoError(t, err)
+	goldenProgram := "ASAIAcCWsQICAMDEBx5kkE4mAyCztwQn0+DycN+vsk+vJWcsoz/b7NDS6i33HOkvTpf+YiC3qUpIgHGWE8/1LPh9SGCalSN7IaITeeWSXbfsS5wsXyC4kBQ38Z8zcwWVAym4S8vpFB/c0XC6R4mnPi9EBADsPDEQIhIxASMMEDIEJBJAABkxCSgSMQcyAxIQMQglEhAxAiEEDRAiQAAuMwAAMwEAEjEJMgMSEDMABykSEDMBByoSEDMACCEFCzMBCCEGCxIQMwAIIQcPEBA="
+	require.Equal(t, goldenProgram, base64.StdEncoding.EncodeToString(c.GetProgram()))
+	goldenAddress := "KPYGWKTV7CKMPMTLQRNGMEQRSYTYDHUOFNV4UDSBDLC44CLIJPQWRTCPBU"
+	require.Equal(t, goldenAddress, c.GetAddress())
 }

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -2,6 +2,8 @@ package templates
 
 import (
 	"encoding/base64"
+	"fmt"
+	"github.com/algorand/go-algorand-sdk/types"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -25,7 +27,7 @@ func TestSplit(t *testing.T) {
 
 func TestHTLC(t *testing.T) {
 	// Inputs
-	owner := "726KBOYUJJNE5J5UHCSGQGWIBZWKCBN4WYD7YVSTEXEVNFPWUIJ7TAEOPM"
+	owner := "ç"
 	receiver := "42NJMHTPFVPXVSDGA6JGKUV6TARV5UZTMPFIREMLXHETRKIVW34QFSDFRE"
 	hashFn := "sha256"
 	hashImg := "f4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGk="
@@ -38,4 +40,31 @@ func TestHTLC(t *testing.T) {
 	require.Equal(t, goldenProgram, base64.StdEncoding.EncodeToString(c.GetProgram()))
 	goldenAddress := "KNBD7ATNUVQ4NTLOI72EEUWBVMBNKMPHWVBCETERV2W7T2YO6CVMLJRBM4"
 	require.Equal(t, goldenAddress, c.GetAddress())
+}
+
+func TestLimitOrder(t *testing.T) {
+	const referenceProgram = "ASAKAAEFAgYEBwgJCiYBIP68oLsUSlpOp7Q4pGgayA5soQW8tgf8VlMlyVaV9qITMRYiEjEQIxIQMQEkDhAyBCMSQABVMgQlEjEIIQQNEDEJMgMSEDMBECEFEhAzAREhBhIQMwEUKBIQMwETMgMSEDMBEiEHHTUCNQExCCEIHTUENQM0ATQDDUAAJDQBNAMSNAI0BA8QQAAWADEJKBIxAiEJDRAxBzIDEhAxCCISEBA="
+	referenceAsBytes, _ := base64.StdEncoding.DecodeString(referenceProgram)
+	addressToFind := "726KBOYUJJNE5J5UHCSGQGWIBZWKCBN4WYD7YVSTEXEVNFPWUIJ7TAEOPM"
+	addressBytes, _ := types.DecodeAddress(addressToFind)
+	for position, _ := range referenceAsBytes {
+		if addressBytes[0] == referenceAsBytes[position] && addressBytes[1] == referenceAsBytes[position+1] && addressBytes[2] == referenceAsBytes[position+2] {
+			fmt.Printf("found the address at position %d \n", position)
+		}
+	}
+
+	return
+	//// Inputs
+	//owner := "726KBOYUJJNE5J5UHCSGQGWIBZWKCBN4WYD7YVSTEXEVNFPWUIJ7TAEOPM"
+	//ratn, ratd := uint64(30), uint64(100) // for N algos, swap for (ratn/ratd)*N assets
+	//expiryRound := uint64(123456)
+	//minTrade := uint64(10000)
+	//maxFee := uint64(5000000)
+	//c, err := MakeLimitOrder(owner, ratn, ratd, expiryRound, minTrade, maxFee)
+	//// Outputs
+	//require.NoError(t, err)
+	//goldenProgram := "ASAIAcCWsQICAMDEBx5kkE4mAyCztwQn0+DycN+vsk+vJWcsoz/b7NDS6i33HOkvTpf+YiC3qUpIgHGWE8/1LPh9SGCalSN7IaITeeWSXbfsS5wsXyC4kBQ38Z8zcwWVAym4S8vpFB/c0XC6R4mnPi9EBADsPDEQIhIxASMMEDIEJBJAABkxCSgSMQcyAxIQMQglEhAxAiEEDRAiQAAuMwAAMwEAEjEJMgMSEDMABykSEDMBByoSEDMACCEFCzMBCCEGCxIQMwAIIQcPEBA="
+	//require.Equal(t, goldenProgram, base64.StdEncoding.EncodeToString(c.GetProgram()))
+	//goldenAddress := "KPYGWKTV7CKMPMTLQRNGMEQRSYTYDHUOFNV4UDSBDLC44CLIJPQWRTCPBU"
+	//require.Equal(t, goldenAddress, c.GetAddress())
 }

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -25,7 +25,7 @@ func TestSplit(t *testing.T) {
 
 func TestHTLC(t *testing.T) {
 	// Inputs
-	owner := "ç"
+	owner := "726KBOYUJJNE5J5UHCSGQGWIBZWKCBN4WYD7YVSTEXEVNFPWUIJ7TAEOPM"
 	receiver := "42NJMHTPFVPXVSDGA6JGKUV6TARV5UZTMPFIREMLXHETRKIVW34QFSDFRE"
 	hashFn := "sha256"
 	hashImg := "f4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGk="

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -44,15 +44,15 @@ func TestLimitOrder(t *testing.T) {
 	// Inputs
 	owner := "726KBOYUJJNE5J5UHCSGQGWIBZWKCBN4WYD7YVSTEXEVNFPWUIJ7TAEOPM"
 	assetid := uint64(12345)
-	ratn, ratd := uint64(30), uint64(100) // for N algos, swap for (ratn/ratd)*N assets
+	ratn, ratd := uint64(30), uint64(100)
 	expiryRound := uint64(123456)
 	minTrade := uint64(10000)
 	maxFee := uint64(5000000)
 	c, err := MakeLimitOrder(owner, assetid, ratn, ratd, expiryRound, minTrade, maxFee)
 	// Outputs
 	require.NoError(t, err)
-	goldenProgram := "ASAIAcCWsQICAMDEBx5kkE4mAyCztwQn0+DycN+vsk+vJWcsoz/b7NDS6i33HOkvTpf+YiC3qUpIgHGWE8/1LPh9SGCalSN7IaITeeWSXbfsS5wsXyC4kBQ38Z8zcwWVAym4S8vpFB/c0XC6R4mnPi9EBADsPDEQIhIxASMMEDIEJBJAABkxCSgSMQcyAxIQMQglEhAxAiEEDRAiQAAuMwAAMwEAEjEJMgMSEDMABykSEDMBByoSEDMACCEFCzMBCCEGCxIQMwAIIQcPEBA="
+	goldenProgram := "ASAKAAHAlrECApBOBLlgZB7AxAcmASD+vKC7FEpaTqe0OKRoGsgObKEFvLYH/FZTJclWlfaiEzEWIhIxECMSEDEBJA4QMgQjEkAAVTIEJRIxCCEEDRAxCTIDEhAzARAhBRIQMwERIQYSEDMBFCgSEDMBEzIDEhAzARIhBx01AjUBMQghCB01BDUDNAE0Aw1AACQ0ATQDEjQCNAQPEEAAFgAxCSgSMQIhCQ0QMQcyAxIQMQgiEhAQ"
 	require.Equal(t, goldenProgram, base64.StdEncoding.EncodeToString(c.GetProgram()))
-	goldenAddress := "KPYGWKTV7CKMPMTLQRNGMEQRSYTYDHUOFNV4UDSBDLC44CLIJPQWRTCPBU"
+	goldenAddress := "LXQWT2XLIVNFS54VTLR63UY5K6AMIEWI7YTVE6LB4RWZDBZKH22ZO3S36I"
 	require.Equal(t, goldenAddress, c.GetAddress())
 }


### PR DESCRIPTION
## Summary
This template implements `limit-order-a.teal.impl` from `go-algorand`.

### Testing
Automatic unit/sdk testing. Added a golden test for program and address.

### See also
https://github.com/algorand/go-algorand-sdk/issues/98