### PR TITLE
Add support for rekeying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.3.0
+# Added
+-  additional Algorand Smart Contracts (ASC)
+    -  support for Dynamic Fee contract
+    -  support for Limit Order contract
+    -  support for Periodic Payment contract
+- support for SuggestedParams
+- support for RawBlock request
+- Missing transaction types 
 # 1.2.1
 # Added
 - Added asset decimals field.

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ build: generate
 
 unit:
 	go test $(TEST_SOURCES_NO_CUCUMBER)
-	cd test && go test --godog.strict=true --godog.format=progress --godog.tags="@unit.offline,@unit.algod,@unit.indexer" --test.v .
+	cd test && go test --godog.strict=true --godog.format=progress --godog.tags="@unit.offline,@unit.algod,@unit.indexer,@unit.rekey" --test.v .
 
 integration:
 	go test $(TEST_SOURCES_NO_CUCUMBER)
-	cd test && go test --godog.strict=true --godog.format=progress --godog.tags="@algod,@assets,@auction,@kmd,@send,@template,@indexer" --test.v .
+	cd test && go test --godog.strict=true --godog.format=progress --godog.tags="@algod,@assets,@auction,@kmd,@send,@template,@indexer,@rekey" --test.v .
 
 docker-test:
 	./test/docker/run_docker.sh

--- a/README.md
+++ b/README.md
@@ -997,3 +997,19 @@ params := types.SuggestedParams {
 // if and only if sender == clawback manager for this asset
 txn, err = MakeAssetRevocationTxn(revocationManager, revocationTarget, amount, recipient, note, params, assetIndex);
 ```
+
+## Rekying
+To rekey an account to a new address, simply call the `Rekey` function on any transaction.
+```golang
+...
+tx, err := future.MakePaymentTxn(
+		account.Address.String(), "4MYUHDWHWXAKA5KA7U5PEN646VYUANBFXVJNONBK3TIMHEMWMD4UBOJBI4",
+		amount, nil, "", params
+	)
+// From now, every transaction needs to be sign the SK of the following address
+tx.Rekey("47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU")
+...
+```
+
+When submitting a transaction from an account that was rekeying, simply use relevant SK. `SignTransaction` will detect 
+that the SK corresponding address is different than the sender's and will set the `AuthAddr` accordingly. 

--- a/client/kmd/requests.go
+++ b/client/kmd/requests.go
@@ -115,9 +115,10 @@ type ListKeysRequest struct {
 // SignTransactionRequest is the request for `POST /v1/transaction/sign`
 type SignTransactionRequest struct {
 	APIV1RequestEnvelope
-	WalletHandleToken string `json:"wallet_handle_token"`
-	Transaction       []byte `json:"transaction"`
-	WalletPassword    string `json:"wallet_password"`
+	WalletHandleToken string            `json:"wallet_handle_token"`
+	Transaction       []byte            `json:"transaction"`
+	WalletPassword    string            `json:"wallet_password"`
+	PublicKey         ed25519.PublicKey `json:"public_key"`
 }
 
 // ListMultisigRequest is the request for `POST /v1/multisig/list`

--- a/client/kmd/wrappers.go
+++ b/client/kmd/wrappers.go
@@ -177,8 +177,24 @@ func (kcl Client) ListKeys(walletHandle string) (resp ListKeysResponse, err erro
 	return
 }
 
-// SignTransaction accepts a wallet handle, wallet password, and transaction,
-// and returns and SignTransactionResponse containing an encoded, signed
+// SignTransactionWithSpecificPublicKey accepts a wallet handle, a wallet password, a transaction,
+// and a public key to sign with its corresponding sk, and returns and SignTransactionResponse containing
+// an encoded, signed transaction. The transaction is signed using the key corresponding to the
+// Sender field.
+func (kcl Client) SignTransactionWithSpecificPublicKey(walletHandle, walletPassword string, tx types.Transaction, pk ed25519.PublicKey) (resp SignTransactionResponse, err error) {
+	txBytes := msgpack.Encode(tx)
+	req := SignTransactionRequest{
+		WalletHandleToken: walletHandle,
+		WalletPassword:    walletPassword,
+		Transaction:       txBytes,
+		PublicKey:         pk,
+	}
+	err = kcl.DoV1Request(req, &resp)
+	return
+}
+
+// SignTransaction accepts a wallet handle, a wallet password, a transaction,
+// and returns SignTransactionResponse containing an encoded, signed
 // transaction. The transaction is signed using the key corresponding to the
 // Sender field.
 func (kcl Client) SignTransaction(walletHandle, walletPassword string, tx types.Transaction) (resp SignTransactionResponse, err error) {

--- a/client/v2/common/models/filtermodels.go
+++ b/client/v2/common/models/filtermodels.go
@@ -67,6 +67,9 @@ type SearchAccountsParams struct {
 
 	// Round for results.
 	Round uint64 `url:"round,omitempty"`
+
+	// Include accounts associated with this spending key.
+	AuthAddr string `url:"auth-addr,omitempty"`
 }
 
 // LookupAccountByIDParams defines parameters for LookupAccountByID.
@@ -121,6 +124,9 @@ type LookupAccountTransactionsParams struct {
 
 	// Used for pagination.
 	NextToken string `url:"next,omitempty"`
+
+	// Whether to include rekeying transactions
+	RekeyTo bool `url:"rekey-to,omitempty"`
 }
 
 // SearchForAssetsParams defines parameters for SearchForAssets.
@@ -221,6 +227,9 @@ type LookupAssetTransactionsParams struct {
 
 	// Used for pagination.
 	NextToken string `url:"next,omitempty"`
+
+	// Whether to include rekeying transactions
+	RekeyTo bool `url:"rekey-to,omitempty"`
 }
 
 // SearchForTransactionsParams defines parameters for SearchForTransactions.
@@ -277,4 +286,7 @@ type SearchForTransactionsParams struct {
 
 	// Used for pagination.
 	NextToken string `url:"next,omitempty"`
+
+	// Whether to include rekeying transactions
+	RekeyTo bool `url:"rekey-to,omitempty"`
 }

--- a/client/v2/common/models/responsemodels.go
+++ b/client/v2/common/models/responsemodels.go
@@ -50,6 +50,11 @@ type Account struct {
 	// * msig
 	// * lsig
 	Type string `json:"sig-type,omitempty"`
+
+	// \[spend\] the address against which signing should be checked.
+	// If empty, the address of the current account is used.
+	// This field can be updated in any transaction by setting the RekeyTo field.
+	AuthAddr string `json:"auth-addr,omitempty"`
 }
 
 // AccountParticipation describes the parameters used by this account in consensus protocol.
@@ -406,6 +411,11 @@ type Transaction struct {
 	// * \[axfer\] asset-transfer-transaction
 	// * \[afrz\] asset-freeze-transaction
 	Type string `json:"tx-type"`
+
+	// \[rekey\] when included in a valid transaction,
+	// the accounts auth addr will be updated with this value
+	// and future signatures must be signed with the key represented by this address.
+	RekeyTo string `json:"rekey-to,omitempty"`
 }
 
 // TransactionAssetConfig defines model for TransactionAssetConfig.

--- a/client/v2/indexer/lookupAccountTransactions.go
+++ b/client/v2/indexer/lookupAccountTransactions.go
@@ -96,6 +96,11 @@ func (s *LookupAccountTransactions) CurrencyLessThan(lessThan uint64) *LookupAcc
 	return s
 }
 
+func (s *LookupAccountTransactions) RekeyTo(rekeyTo bool) *LookupAccountTransactions {
+	s.p.RekeyTo = rekeyTo
+	return s
+}
+
 func (s *LookupAccountTransactions) Do(ctx context.Context, headers ...*common.Header) (response models.TransactionsResponse, err error) {
 	err = s.c.get(ctx, &response, fmt.Sprintf("/v2/accounts/%s/transactions", s.account), s.p, headers)
 	return

--- a/client/v2/indexer/lookupAssetTransactions.go
+++ b/client/v2/indexer/lookupAssetTransactions.go
@@ -111,6 +111,11 @@ func (s *LookupAssetTransactions) ExcludeCloseTo(exclude bool) *LookupAssetTrans
 	return s
 }
 
+func (s *LookupAssetTransactions) RekeyTo(rekeyTo bool) *LookupAssetTransactions {
+	s.p.RekeyTo = rekeyTo
+	return s
+}
+
 func (s *LookupAssetTransactions) Do(ctx context.Context, headers ...*common.Header) (response models.TransactionsResponse, err error) {
 	err = s.c.get(ctx, &response, fmt.Sprintf("/v2/assets/%d/transactions", s.index), s.p, headers)
 	return

--- a/client/v2/indexer/searchAccounts.go
+++ b/client/v2/indexer/searchAccounts.go
@@ -46,6 +46,11 @@ func (s *SearchAccounts) Round(round uint64) *SearchAccounts {
 	return s
 }
 
+func (s *SearchAccounts) AuthAddress(authAddr string) *SearchAccounts {
+	s.p.AuthAddr = authAddr
+	return s
+}
+
 func (s *SearchAccounts) Do(ctx context.Context, headers ...*common.Header) (response models.AccountsResponse, err error) {
 	err = s.c.get(ctx, &response, "/v2/accounts", s.p, headers)
 	return

--- a/client/v2/indexer/searchForTransactions.go
+++ b/client/v2/indexer/searchForTransactions.go
@@ -114,6 +114,11 @@ func (s *SearchForTransactions) ExcludeCloseTo(exclude bool) *SearchForTransacti
 	return s
 }
 
+func (s *SearchForTransactions) RekeyTo(rekeyTo bool) *SearchForTransactions {
+	s.p.RekeyTo = rekeyTo
+	return s
+}
+
 func (s *SearchForTransactions) Do(ctx context.Context, headers ...*common.Header) (response models.TransactionsResponse, err error) {
 	err = s.c.get(ctx, &response, "/v2/transactions", s.p, headers)
 	return

--- a/test/indexer_unit_test.go
+++ b/test/indexer_unit_test.go
@@ -30,7 +30,8 @@ func IndexerUnitTestContext(s *godog.Suite) {
 	s.Step(`^we make any SearchForAssets call$`, weMakeAnySearchForAssetsCall)
 	s.Step(`^the parsed SearchForAssets response should be valid on round (\d+) and the array should be of len (\d+) and the element at index (\d+) should have asset index (\d+)$`, theParsedSearchForAssetsResponseShouldBeValidOnRoundAndTheArrayShouldBeOfLenAndTheElementAtIndexShouldHaveAssetIndex)
 	s.Step(`^we make a Lookup Asset Balances call against asset index (\d+) with limit <limit> afterAddress "([^"]*)" round (\d+) currencyGreaterThan (\d+) currencyLessThan (\d+)$`, weMakeALookupAssetBalancesCallAgainstAssetIndexWithLimitLimitAfterAddressRoundCurrencyGreaterThanCurrencyLessThan)
-	s.Step(`^we make a Lookup Asset Transactions call against asset index (\d+) with NotePrefix "([^"]*)" TxType "([^"]*)" SigType "([^"]*)" txid "([^"]*)" round (\d+) minRound (\d+) maxRound (\d+) limit (\d+) beforeTime (\d+) afterTime (\d+) currencyGreaterThan (\d+) currencyLessThan (\d+) address "([^"]*)" addressRole "([^"]*)" ExcluseCloseTo "([^"]*)"$`, weMakeALookupAssetTransactionsCallAgainstAssetIndexWithNotePrefixTxTypeSigTypeTxidRoundMinRoundMaxRoundLimitBeforeTimeAfterTimeCurrencyGreaterThanCurrencyLessThanAddressAddressRoleExcluseCloseTo)
+	s.Step(`^we make a Lookup Asset Transactions call against asset index (\d+) with NotePrefix "([^"]*)" TxType "([^"]*)" SigType "([^"]*)" txid "([^"]*)" round (\d+) minRound (\d+) maxRound (\d+) limit (\d+) beforeTime "([^"]*)" afterTime "([^"]*)" currencyGreaterThan (\d+) currencyLessThan (\d+) address "([^"]*)" addressRole "([^"]*)" ExcluseCloseTo "([^"]*)"$`, weMakeALookupAssetTransactionsCallAgainstAssetIndexWithNotePrefixTxTypeSigTypeTxidRoundMinRoundMaxRoundLimitBeforeTimeAfterTimeCurrencyGreaterThanCurrencyLessThanAddressAddressRoleExcluseCloseTo)
+	s.Step(`^we make a Search Accounts call with assetID (\d+) limit (\d+) currencyGreaterThan (\d+) currencyLessThan (\d+) and round (\d+)$`, weMakeASearchAccountsCallWithAssetIDLimitCurrencyGreaterThanCurrencyLessThanAndRound)
 	s.Step(`^we make a Lookup Account Transactions call against account "([^"]*)" with NotePrefix "([^"]*)" TxType "([^"]*)" SigType "([^"]*)" txid "([^"]*)" round (\d+) minRound (\d+) maxRound (\d+) limit (\d+) beforeTime "([^"]*)" afterTime "([^"]*)" currencyGreaterThan (\d+) currencyLessThan (\d+) assetIndex (\d+)$`, weMakeALookupAccountTransactionsCallAgainstAccountWithNotePrefixTxTypeSigTypeTxidRoundMinRoundMaxRoundLimitBeforeTimeAfterTimeCurrencyGreaterThanCurrencyLessThanAssetIndex)
 	s.Step(`^we make a Lookup Block call against round (\d+)$`, weMakeALookupBlockCallAgainstRound)
 	s.Step(`^we make a Lookup Account by ID call against account "([^"]*)" with round (\d+)$`, weMakeALookupAccountByIDCallAgainstAccountWithRound)
@@ -40,10 +41,14 @@ func IndexerUnitTestContext(s *godog.Suite) {
 	s.Step(`^we make a SearchForAssets call with limit (\d+) creator "([^"]*)" name "([^"]*)" unit "([^"]*)" index (\d+) and afterAsset (\d+)$`, weMakeASearchForAssetsCallWithLimitCreatorNameUnitIndexAndAfterAsset)
 	s.Step(`^mock server recording request paths`, mockServerRecordingRequestPaths)
 	s.Step(`^we make a Lookup Asset Balances call against asset index (\d+) with limit (\d+) afterAddress "([^"]*)" round (\d+) currencyGreaterThan (\d+) currencyLessThan (\d+)$`, weMakeALookupAssetBalancesCallAgainstAssetIndexWithLimitAfterAddressRoundCurrencyGreaterThanCurrencyLessThan)
-	s.Step(`^we make a Lookup Asset Transactions call against asset index (\d+) with NotePrefix "([^"]*)" TxType "([^"]*)" SigType "([^"]*)" txid "([^"]*)" round (\d+) minRound (\d+) maxRound (\d+) limit (\d+) beforeTime "([^"]*)" afterTime "([^"]*)" currencyGreaterThan (\d+) currencyLessThan (\d+) address "([^"]*)" addressRole "([^"]*)" ExcluseCloseTo "([^"]*)"$`, weMakeALookupAssetTransactionsCallAgainstAssetIndexWithNotePrefixTxTypeSigTypeTxidRoundMinRoundMaxRoundLimitBeforeTimeAfterTimeCurrencyGreaterThanCurrencyLessThanAddressAddressRoleExcluseCloseTo)
-	s.Step(`^we make a Search Accounts call with assetID (\d+) limit (\d+) currencyGreaterThan (\d+) currencyLessThan (\d+) and round (\d+)$`, weMakeASearchAccountsCallWithAssetIDLimitCurrencyGreaterThanCurrencyLessThanAndRound)
 	s.Step(`^we make a Search For Transactions call with account "([^"]*)" NotePrefix "([^"]*)" TxType "([^"]*)" SigType "([^"]*)" txid "([^"]*)" round (\d+) minRound (\d+) maxRound (\d+) limit (\d+) beforeTime "([^"]*)" afterTime "([^"]*)" currencyGreaterThan (\d+) currencyLessThan (\d+) assetIndex (\d+) addressRole "([^"]*)" ExcluseCloseTo "([^"]*)"$`, weMakeASearchForTransactionsCallWithAccountNotePrefixTxTypeSigTypeTxidRoundMinRoundMaxRoundLimitBeforeTimeAfterTimeCurrencyGreaterThanCurrencyLessThanAssetIndexAddressRoleExcluseCloseTo)
 	s.Step(`^we make a SearchForAssets call with limit (\d+) creator "([^"]*)" name "([^"]*)" unit "([^"]*)" index (\d+)$`, weMakeASearchForAssetsCallWithLimitCreatorNameUnitIndex)
+	s.Step(`^we make a Lookup Account Transactions call against account "([^"]*)" with NotePrefix "([^"]*)" TxType "([^"]*)" SigType "([^"]*)" txid "([^"]*)" round (\d+) minRound (\d+) maxRound (\d+) limit (\d+) beforeTime "([^"]*)" afterTime "([^"]*)" currencyGreaterThan (\d+) currencyLessThan (\d+) assetIndex (\d+) rekeyTo "([^"]*)"$`, weMakeALookupAccountTransactionsCallAgainstAccountWithNotePrefixTxTypeSigTypeTxidRoundMinRoundMaxRoundLimitBeforeTimeAfterTimeCurrencyGreaterThanCurrencyLessThanAssetIndexRekeyTo)
+	s.Step(`^we make a Search Accounts call with assetID (\d+) limit (\d+) currencyGreaterThan (\d+) currencyLessThan (\d+) round (\d+) and authenticating address "([^"]*)"$`, weMakeASearchAccountsCallWithAssetIDLimitCurrencyGreaterThanCurrencyLessThanRoundAndAuthenticatingAddress)
+	s.Step(`^we make a Search For Transactions call with account "([^"]*)" NotePrefix "([^"]*)" TxType "([^"]*)" SigType "([^"]*)" txid "([^"]*)" round (\d+) minRound (\d+) maxRound (\d+) limit (\d+) beforeTime "([^"]*)" afterTime "([^"]*)" currencyGreaterThan (\d+) currencyLessThan (\d+) assetIndex (\d+) addressRole "([^"]*)" ExcluseCloseTo "([^"]*)" rekeyTo "([^"]*)"$`, weMakeASearchForTransactionsCallWithAccountNotePrefixTxTypeSigTypeTxidRoundMinRoundMaxRoundLimitBeforeTimeAfterTimeCurrencyGreaterThanCurrencyLessThanAssetIndexAddressRoleExcluseCloseToRekeyTo)
+	s.Step(`^the parsed SearchAccounts response should be valid on round (\d+) and the array should be of len (\d+) and the element at index (\d+) should have authorizing address "([^"]*)"$`, theParsedSearchAccountsResponseShouldBeValidOnRoundAndTheArrayShouldBeOfLenAndTheElementAtIndexShouldHaveAuthorizingAddress)
+	s.Step(`^the parsed SearchForTransactions response should be valid on round (\d+) and the array should be of len (\d+) and the element at index (\d+) should have rekey-to "([^"]*)"$`, theParsedSearchForTransactionsResponseShouldBeValidOnRoundAndTheArrayShouldBeOfLenAndTheElementAtIndexShouldHaveRekeyto)
+	s.Step(`^we make a Lookup Asset Transactions call against asset index (\d+) with NotePrefix "([^"]*)" TxType "([^"]*)" SigType "([^"]*)" txid "([^"]*)" round (\d+) minRound (\d+) maxRound (\d+) limit (\d+) beforeTime "([^"]*)" afterTime "([^"]*)" currencyGreaterThan (\d+) currencyLessThan (\d+) address "([^"]*)" addressRole "([^"]*)" ExcluseCloseTo "([^"]*)" RekeyTo "([^"]*)"$`, weMakeALookupAssetTransactionsCallAgainstAssetIndexWithNotePrefixTxTypeSigTypeTxidRoundMinRoundMaxRoundLimitBeforeTimeAfterTimeCurrencyGreaterThanCurrencyLessThanAddressAddressRoleExcluseCloseToRekeyTo)
 	s.BeforeScenario(func(interface{}) {
 		globalErrForExamination = nil
 	})
@@ -238,6 +243,21 @@ func theParsedSearchAccountsResponseShouldBeValidOnRoundAndTheArrayShouldBeOfLen
 	return nil
 }
 
+func theParsedSearchAccountsResponseShouldBeValidOnRoundAndTheArrayShouldBeOfLenAndTheElementAtIndexShouldHaveAuthorizingAddress(round, length, idx int, address string) error {
+	if responseValidRound != uint64(round) {
+		return fmt.Errorf("response round %d did not match expected round %d", responseValidRound, uint64(round))
+	}
+	realLen := len(searchAccountsResponse)
+	if realLen != length {
+		return fmt.Errorf("response length %d did not match expected length %d", realLen, length)
+	}
+	scrutinizedElement := searchAccountsResponse[idx]
+	if scrutinizedElement.AuthAddr != address {
+		return fmt.Errorf("response auth-address %s did not match expected auth-address %s", scrutinizedElement.AuthAddr, address)
+	}
+	return nil
+}
+
 var searchTransactionsResponse []models.Transaction
 
 func weMakeAnySearchForTransactionsCall() error {
@@ -263,6 +283,21 @@ func theParsedSearchForTransactionsResponseShouldBeValidOnRoundAndTheArrayShould
 	scrutinizedElement := searchTransactionsResponse[idx]
 	if scrutinizedElement.Sender != sender {
 		return fmt.Errorf("response sender %s did not match expected sender %s", scrutinizedElement.Sender, sender)
+	}
+	return nil
+}
+
+func theParsedSearchForTransactionsResponseShouldBeValidOnRoundAndTheArrayShouldBeOfLenAndTheElementAtIndexShouldHaveRekeyto(round, length, idx int, rekeyTo string) error {
+	if responseValidRound != uint64(round) {
+		return fmt.Errorf("response round %d did not match expected round %d", responseValidRound, uint64(round))
+	}
+	realLen := len(searchTransactionsResponse)
+	if realLen != length {
+		return fmt.Errorf("response length %d did not match expected length %d", realLen, length)
+	}
+	scrutinizedElement := searchTransactionsResponse[idx]
+	if scrutinizedElement.RekeyTo != rekeyTo {
+		return fmt.Errorf("response rekey-to %s did not match expected rekey-to %s", scrutinizedElement.RekeyTo, rekeyTo)
 	}
 	return nil
 }
@@ -316,6 +351,21 @@ func weMakeALookupAssetTransactionsCallAgainstAssetIndexWithNotePrefixTxTypeSigT
 	return nil
 }
 
+func weMakeALookupAssetTransactionsCallAgainstAssetIndexWithNotePrefixTxTypeSigTypeTxidRoundMinRoundMaxRoundLimitBeforeTimeAfterTimeCurrencyGreaterThanCurrencyLessThanAddressAddressRoleExcluseCloseToRekeyTo(assetIndex int, notePrefix, txType, sigType, txid string, round, minRound, maxRound, limit int, beforeTime, afterTime string, currencyGreater, currencyLesser int, address, addressRole, excludeCloseTo, rekeyTo string) error {
+	indexerClient, err := indexer.MakeClient(mockServer.URL, "")
+	if err != nil {
+		return err
+	}
+	excludeCloseToBool := excludeCloseTo == "true"
+	notePrefixBytes, err := base64.StdEncoding.DecodeString(notePrefix)
+	if err != nil {
+		return err
+	}
+	rekeyToBool := rekeyTo == "true"
+	_, globalErrForExamination = indexerClient.LookupAssetTransactions(uint64(assetIndex)).NotePrefix(notePrefixBytes).TxType(txType).SigType(sigType).TXID(txid).Round(uint64(round)).MinRound(uint64(minRound)).MaxRound(uint64(maxRound)).Limit(uint64(limit)).BeforeTimeString(beforeTime).AfterTimeString(afterTime).CurrencyGreaterThan(uint64(currencyGreater)).CurrencyLessThan(uint64(currencyLesser)).AddressString(address).AddressRole(addressRole).ExcludeCloseTo(excludeCloseToBool).RekeyTo(rekeyToBool).Do(context.Background())
+	return nil
+}
+
 func weMakeALookupAccountTransactionsCallAgainstAccountWithNotePrefixTxTypeSigTypeTxidRoundMinRoundMaxRoundLimitBeforeTimeAfterTimeCurrencyGreaterThanCurrencyLessThanAssetIndex(account, notePrefix, txType, sigType, txid string, round, minRound, maxRound, limit int, beforeTime, afterTime string, currencyGreater, currencyLesser, assetIndex int) error {
 	indexerClient, err := indexer.MakeClient(mockServer.URL, "")
 	if err != nil {
@@ -326,6 +376,20 @@ func weMakeALookupAccountTransactionsCallAgainstAccountWithNotePrefixTxTypeSigTy
 		return err
 	}
 	_, globalErrForExamination = indexerClient.LookupAccountTransactions(account).NotePrefix(notePrefixBytes).TxType(txType).SigType(sigType).TXID(txid).Round(uint64(round)).MinRound(uint64(minRound)).MaxRound(uint64(maxRound)).Limit(uint64(limit)).BeforeTimeString(beforeTime).AfterTimeString(afterTime).CurrencyGreaterThan(uint64(currencyGreater)).CurrencyLessThan(uint64(currencyLesser)).AssetID(uint64(assetIndex)).Do(context.Background())
+	return nil
+}
+
+func weMakeALookupAccountTransactionsCallAgainstAccountWithNotePrefixTxTypeSigTypeTxidRoundMinRoundMaxRoundLimitBeforeTimeAfterTimeCurrencyGreaterThanCurrencyLessThanAssetIndexRekeyTo(account, notePrefix, txType, sigType, txid string, round, minRound, maxRound, limit int, beforeTime, afterTime string, currencyGreater, currencyLesser, assetIndex int, rekeyTo string) error {
+	indexerClient, err := indexer.MakeClient(mockServer.URL, "")
+	if err != nil {
+		return err
+	}
+	notePrefixBytes, err := base64.StdEncoding.DecodeString(notePrefix)
+	if err != nil {
+		return err
+	}
+	rekeyToBool := rekeyTo == "true"
+	_, globalErrForExamination = indexerClient.LookupAccountTransactions(account).NotePrefix(notePrefixBytes).TxType(txType).SigType(sigType).TXID(txid).Round(uint64(round)).MinRound(uint64(minRound)).MaxRound(uint64(maxRound)).Limit(uint64(limit)).BeforeTimeString(beforeTime).AfterTimeString(afterTime).CurrencyGreaterThan(uint64(currencyGreater)).CurrencyLessThan(uint64(currencyLesser)).AssetID(uint64(assetIndex)).RekeyTo(rekeyToBool).Do(context.Background())
 	return nil
 }
 
@@ -365,6 +429,15 @@ func weMakeASearchAccountsCallWithAssetIDLimitCurrencyGreaterThanCurrencyLessTha
 	return nil
 }
 
+func weMakeASearchAccountsCallWithAssetIDLimitCurrencyGreaterThanCurrencyLessThanRoundAndAuthenticatingAddress(assetIndex, limit, currencyGreater, currencyLesser, round int, authAddress string) error {
+	indexerClient, err := indexer.MakeClient(mockServer.URL, "")
+	if err != nil {
+		return err
+	}
+	_, globalErrForExamination = indexerClient.SearchAccounts().AssetID(uint64(assetIndex)).Limit(uint64(limit)).CurrencyLessThan(uint64(currencyLesser)).CurrencyGreaterThan(uint64(currencyGreater)).Round(uint64(round)).AuthAddress(authAddress).Do(context.Background())
+	return nil
+}
+
 func weMakeASearchForTransactionsCallWithAccountNotePrefixTxTypeSigTypeTxidRoundMinRoundMaxRoundLimitBeforeTimeAfterTimeCurrencyGreaterThanCurrencyLessThanAssetIndexAddressRoleExcluseCloseTo(account, notePrefix, txType, sigType, txid string, round, minRound, maxRound, limit int, beforeTime, afterTime string, currencyGreater, currencyLesser, assetIndex int, addressRole, excludeCloseTo string) error {
 	indexerClient, err := indexer.MakeClient(mockServer.URL, "")
 	if err != nil {
@@ -376,6 +449,21 @@ func weMakeASearchForTransactionsCallWithAccountNotePrefixTxTypeSigTypeTxidRound
 		return err
 	}
 	_, globalErrForExamination = indexerClient.SearchForTransactions().AddressString(account).NotePrefix(notePrefixBytes).TxType(txType).SigType(sigType).TXID(txid).Round(uint64(round)).MinRound(uint64(minRound)).MaxRound(uint64(maxRound)).Limit(uint64(limit)).BeforeTimeString(beforeTime).AfterTimeString(afterTime).CurrencyGreaterThan(uint64(currencyGreater)).CurrencyLessThan(uint64(currencyLesser)).AssetID(uint64(assetIndex)).AddressRole(addressRole).ExcludeCloseTo(excludeCloseToBool).Do(context.Background())
+	return nil
+}
+
+func weMakeASearchForTransactionsCallWithAccountNotePrefixTxTypeSigTypeTxidRoundMinRoundMaxRoundLimitBeforeTimeAfterTimeCurrencyGreaterThanCurrencyLessThanAssetIndexAddressRoleExcluseCloseToRekeyTo(account, notePrefix, txType, sigType, txid string, round, minRound, maxRound, limit int, beforeTime, afterTime string, currencyGreater, currencyLesser, assetIndex int, addressRole, excludeCloseTo, rekeyTo string) error {
+	indexerClient, err := indexer.MakeClient(mockServer.URL, "")
+	if err != nil {
+		return err
+	}
+	excludeCloseToBool := excludeCloseTo == "true"
+	notePrefixBytes, err := base64.StdEncoding.DecodeString(notePrefix)
+	if err != nil {
+		return err
+	}
+	rekeyToBool := rekeyTo == "true"
+	_, globalErrForExamination = indexerClient.SearchForTransactions().AddressString(account).NotePrefix(notePrefixBytes).TxType(txType).SigType(sigType).TXID(txid).Round(uint64(round)).MinRound(uint64(minRound)).MaxRound(uint64(maxRound)).Limit(uint64(limit)).BeforeTimeString(beforeTime).AfterTimeString(afterTime).CurrencyGreaterThan(uint64(currencyGreater)).CurrencyLessThan(uint64(currencyLesser)).AssetID(uint64(assetIndex)).AddressRole(addressRole).ExcludeCloseTo(excludeCloseToBool).RekeyTo(rekeyToBool).Do(context.Background())
 	return nil
 }
 

--- a/test/steps_test.go
+++ b/test/steps_test.go
@@ -155,6 +155,8 @@ func FeatureContext(s *godog.Suite) {
 	s.Step("I create the multisig payment transaction", createMsigTxn)
 	s.Step("I sign the multisig transaction with the private key", signMsigTxn)
 	s.Step("I sign the transaction with the private key", signTxn)
+	s.Step(`^I add a rekeyTo field with address "([^"]*)"$`, iAddARekeyToFieldWithAddress)
+	s.Step(`^I set the from address to "([^"]*)"$`, iSetTheFromAddressTo)
 	s.Step(`the signed transaction should equal the golden "([^"]*)"`, equalGolden)
 	s.Step(`the multisig transaction should equal the golden "([^"]*)"`, equalMsigGolden)
 	s.Step(`the multisig address should equal the golden "([^"]*)"`, equalMsigAddrGolden)
@@ -430,6 +432,15 @@ func msigAddresses(addresses string) error {
 	return err
 }
 
+func iSetTheFromAddressTo(address string) error {
+	addr, err := types.DecodeAddress(address)
+	if err != nil {
+		return err
+	}
+	txn.Sender = addr
+	return nil
+}
+
 func createMsigTxn() error {
 	var err error
 	paramsToUse := types.SuggestedParams{
@@ -459,6 +470,14 @@ func signMsigTxn() error {
 func signTxn() error {
 	var err error
 	txid, stx, err = crypto.SignTransaction(account.PrivateKey, txn)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func iAddARekeyToFieldWithAddress(address string) error {
+	err := txn.Rekey(address)
 	if err != nil {
 		return err
 	}

--- a/test/steps_test.go
+++ b/test/steps_test.go
@@ -156,6 +156,7 @@ func FeatureContext(s *godog.Suite) {
 	s.Step("I sign the multisig transaction with the private key", signMsigTxn)
 	s.Step("I sign the transaction with the private key", signTxn)
 	s.Step(`^I add a rekeyTo field with address "([^"]*)"$`, iAddARekeyToFieldWithAddress)
+	s.Step(`^I add a rekeyTo field with the private key algorand address$`, iAddARekeyToFieldWithThePrivateKeyAlgorandAddress)
 	s.Step(`^I set the from address to "([^"]*)"$`, iSetTheFromAddressTo)
 	s.Step(`the signed transaction should equal the golden "([^"]*)"`, equalGolden)
 	s.Step(`the multisig transaction should equal the golden "([^"]*)"`, equalMsigGolden)
@@ -334,6 +335,20 @@ func tryHandle() error {
 	_, err := kcl.RenewWalletHandle(handle)
 	if err == nil {
 		return fmt.Errorf("should be an error; handle was released")
+	}
+	return nil
+}
+
+func iAddARekeyToFieldWithThePrivateKeyAlgorandAddress() error {
+	pk, err := crypto.GenerateAddressFromSK(account.PrivateKey)
+	if err != nil {
+		return err
+	}
+
+	err = txn.Rekey(pk.String())
+
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -5,11 +5,15 @@ import (
 	"encoding/base64"
 	"fmt"
 	"github.com/algorand/go-algorand-sdk/crypto"
+	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
 	"github.com/algorand/go-algorand-sdk/types"
 )
 
 // MinTxnFee is v5 consensus params, in microAlgos
 const MinTxnFee = 1000
+
+// NumOfAdditionalBytesAfterSigning is the number of bytes added to a txn after signing it
+const NumOfAdditionalBytesAfterSigning = 75
 
 // MakePaymentTxn constructs a payment transaction using the passed parameters.
 // `from` and `to` addresses should be checksummed, human-readable addresses
@@ -786,12 +790,7 @@ func AssignGroupID(txns []types.Transaction, account string) (result []types.Tra
 
 // EstimateSize returns the estimated length of the encoded transaction
 func EstimateSize(txn types.Transaction) (uint64, error) {
-	key := crypto.GenerateAccount()
-	_, stx, err := crypto.SignTransaction(key.PrivateKey, txn)
-	if err != nil {
-		return 0, err
-	}
-	return uint64(len(stx)), nil
+	return uint64(len(msgpack.Encode(txn))) + NumOfAdditionalBytesAfterSigning, nil
 }
 
 // byte32FromBase64 decodes the input base64 string and outputs a

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -206,3 +206,15 @@ func (tx *Transaction) AddLeaseWithFlatFee(lease [32]byte, flatFee uint64) {
 	tx.Header.Lease = lease
 	tx.Header.Fee = MicroAlgos(flatFee)
 }
+
+// Rekey sets the rekeyTo field to the passed address. Any future transacrtion will need to be signed by the
+// rekeyTo address' corresponding private key.
+func (tx *Transaction) Rekey(rekeyToAddress string) error {
+	addr, err := DecodeAddress(rekeyToAddress)
+	if err != nil {
+		return err
+	}
+
+	tx.RekeyTo = addr
+	return nil
+}


### PR DESCRIPTION
This PR adds support for rekeying - 
-- Add the ability to add a `rekey-to` field to any transaction
-- `SignTransaction` now checks if the `SK` is different than the sender's corresponding one and adds `AuthAddr` as needed. 
-- Implements the necessary steps for the cucumber unit and integration tests