### PR TITLE
Do not use main for packages with no main func.

### DIFF
--- a/test/algodclientv2_test.go
+++ b/test/algodclientv2_test.go
@@ -1,10 +1,11 @@
-package main
+package test
 
 import (
 	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
+
 	"github.com/algorand/go-algorand-sdk/client/v2/algod"
 	"github.com/algorand/go-algorand-sdk/client/v2/common/models"
 	"github.com/algorand/go-algorand-sdk/types"

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1,4 +1,4 @@
-package main
+package test
 
 import (
 	"container/ring"

--- a/test/indexer_integration_test.go
+++ b/test/indexer_integration_test.go
@@ -1,4 +1,4 @@
-package main
+package test
 
 import (
 	"context"

--- a/test/indexer_unit_test.go
+++ b/test/indexer_unit_test.go
@@ -1,9 +1,10 @@
-package main
+package test
 
 import (
 	"context"
 	"encoding/base64"
 	"fmt"
+
 	"github.com/algorand/go-algorand-sdk/client/v2/common/models"
 	"github.com/algorand/go-algorand-sdk/client/v2/indexer"
 	"github.com/cucumber/godog"

--- a/test/steps_test.go
+++ b/test/steps_test.go
@@ -1,4 +1,4 @@
-package main
+package test
 
 import (
 	"bytes"


### PR DESCRIPTION
This seems to resolve the go get issue:
```
GO111MODULE=on go get -u github.com/algorand/go-algorand-sdk/...@will/missing-main
```