### PR TITLE
Response and Path tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ build: generate
 
 unit:
 	go test $(TEST_SOURCES_NO_CUCUMBER)
-	cd test && go test --godog.strict=true --godog.format=progress --godog.tags="@unit.offline,@unit.algod,@unit.indexer,@unit.rekey,@unit.tealsign,@unit.dryrun,@unit.responses,@unit.applications" --test.v .
+	cd test && go test --godog.strict=true --godog.format=pretty --godog.tags="@unit.offline,@unit.algod,@unit.indexer,@unit.rekey,@unit.tealsign,@unit.dryrun,@unit.responses,@unit.applications" --test.v .
 
 integration:
 	go test $(TEST_SOURCES_NO_CUCUMBER)
-	cd test && go test --godog.strict=true --godog.format=progress --godog.tags="@algod,@assets,@auction,@kmd,@send,@template,@indexer,@rekey,@dryrun,@compile" --test.v .
+	cd test && go test --godog.strict=true --godog.format=pretty --godog.tags="@algod,@assets,@auction,@kmd,@send,@template,@indexer,@rekey,@dryrun,@compile" --test.v .
 
 docker-test:
 	./test/docker/run_docker.sh

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build: generate
 
 unit:
 	go test $(TEST_SOURCES_NO_CUCUMBER)
-	cd test && go test --godog.strict=true --godog.format=progress --godog.tags="@unit.offline,@unit.algod,@unit.indexer,@unit.rekey,@unit.tealsign,@unit.dryrun" --test.v .
+	cd test && go test --godog.strict=true --godog.format=progress --godog.tags="@unit.offline,@unit.algod,@unit.indexer,@unit.rekey,@unit.tealsign,@unit.dryrun,@unit.responses" --test.v .
 
 integration:
 	go test $(TEST_SOURCES_NO_CUCUMBER)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build: generate
 
 unit:
 	go test $(TEST_SOURCES_NO_CUCUMBER)
-	cd test && go test --godog.strict=true --godog.format=progress --godog.tags="@unit.offline,@unit.algod,@unit.indexer,@unit.rekey,@unit.tealsign,@unit.dryrun,@unit.responses" --test.v .
+	cd test && go test --godog.strict=true --godog.format=progress --godog.tags="@unit.offline,@unit.algod,@unit.indexer,@unit.rekey,@unit.tealsign,@unit.dryrun,@unit.responses,@unit.applications" --test.v .
 
 integration:
 	go test $(TEST_SOURCES_NO_CUCUMBER)

--- a/client/v2/common/models/application_responsemodels.go
+++ b/client/v2/common/models/application_responsemodels.go
@@ -241,13 +241,13 @@ type TransactionApplication struct {
 	// when on-completion is set to "clear". It can read and write global state for the
 	// application, as well as account-specific local state. Approval programs may
 	// reject the transaction.
-	ApprovalProgram string `json:"approval-program,omitempty"`
+	ApprovalProgram []byte `json:"approval-program,omitempty"`
 
 	// ClearStateProgram (apsu) Logic executed for application transactions with
 	// on-completion set to "clear". It can read and write global state for the
 	// application, as well as account-specific local state. Clear state programs
 	// cannot reject the transaction.
-	ClearStateProgram string `json:"clear-state-program,omitempty"`
+	ClearStateProgram []byte `json:"clear-state-program,omitempty"`
 
 	// ForeignApps (apfa) Lists the applications in addition to the application-id
 	// whose global states may be accessed by this application's approval-program and

--- a/client/v2/common/models/application_responsemodels.go
+++ b/client/v2/common/models/application_responsemodels.go
@@ -231,7 +231,7 @@ type TransactionApplication struct {
 
 	// ApplicationArgs (apaa) transaction specific arguments accessed from the
 	// application's approval-program and clear-state-program.
-	ApplicationArgs []byte `json:"application-args,omitempty"`
+	ApplicationArgs [][]byte `json:"application-args,omitempty"`
 
 	// ApplicationId (apid) ID of the application being configured or empty if
 	// creating.

--- a/client/v2/common/models/responsemodels.go
+++ b/client/v2/common/models/responsemodels.go
@@ -333,6 +333,10 @@ type Supply struct {
 
 // Transaction defines model for Transaction.
 type Transaction struct {
+	// ApplicationTransaction fields for application transactions.
+	// Definition:
+	// data/transactions/application.go : ApplicationCallTxnFields
+	ApplicationTransaction TransactionApplication `json:"application-transaction,omitempty"`
 
 	// Fields for asset allocation, re-configuration, and destruction.
 	//
@@ -356,6 +360,11 @@ type Transaction struct {
 	// data/transactions/asset.go : AssetTransferTxnFields
 	AssetTransferTransaction TransactionAssetTransfer `json:"asset-transfer-transaction,omitempty"`
 
+	// AuthAddr (sgnr) The address used to sign the transaction. This is used for
+	// rekeyed accounts to indicate that the sender address did not sign the
+	// transaction.
+	AuthAddr string `json:"auth-addr,omitempty"`
+
 	// \[rc\] rewards applied to close-remainder-to account.
 	CloseRewards uint64 `json:"close-rewards,omitempty"`
 
@@ -364,6 +373,10 @@ type Transaction struct {
 
 	// Round when the transaction was confirmed.
 	ConfirmedRound uint64 `json:"confirmed-round,omitempty"`
+
+	// CreatedApplicationIndex specifies an application index (ID) if an application
+	// was created with this transaction.
+	CreatedApplicationIndex uint64 `json:"created-application-index,omitempty"`
 
 	// Specifies an asset index (ID) if an asset was created with this transaction.
 	CreatedAssetIndex uint64 `json:"created-asset-index,omitempty"`
@@ -385,6 +398,9 @@ type Transaction struct {
 
 	// Transaction ID
 	Id string `json:"id"`
+
+	// IntraRoundOffset offset into the round where this transaction was confirmed.
+	IntraRoundOffset uint64 `json:"intra-round-offset,omitempty"`
 
 	// Fields for a keyreg transaction.
 	//

--- a/client/v2/common/models/responsemodels.go
+++ b/client/v2/common/models/responsemodels.go
@@ -289,12 +289,30 @@ type MiniAssetHolding struct {
 
 // NodeStatus contains the information about a node's 'status.
 type NodeStatus struct {
+	// Catchpoint the current catchpoint that is being caught up to
+	Catchpoint string `json:"catchpoint,omitempty"`
+
+	// CatchpointAcquiredBlocks the number of blocks that have already been obtained by
+	// the node as part of the catchup
+	CatchpointAcquiredBlocks uint64 `json:"catchpoint-acquired-blocks,omitempty"`
+
+	// CatchpointProcessedAccounts the number of account from the current catchpoint
+	// that have been processed so far as part of the catchup
+	CatchpointProcessedAccounts uint64 `json:"catchpoint-processed-accounts,omitempty"`
+
+	// CatchpointTotalAccounts the total number of accounts included in the current
+	// catchpoint
+	CatchpointTotalAccounts uint64 `json:"catchpoint-total-accounts,omitempty"`
+
+	// CatchpointTotalBlocks the total number of blocks that are required to complete
+	// the current catchpoint catchup
+	CatchpointTotalBlocks uint64 `json:"catchpoint-total-blocks,omitempty"`
 
 	// CatchupTime in nanoseconds
 	CatchupTime uint64 `json:"catchup-time"`
 
-	// HasSyncedSinceStartup indicates whether a round has completed since startup
-	HasSyncedSinceStartup bool `json:"has-synced-since-startup"`
+	// LastCatchpoint the last catchpoint seen by the node
+	LastCatchpoint string `json:"last-catchpoint,omitempty"`
 
 	// LastRound indicates the last round seen
 	LastRound uint64 `json:"last-round"`

--- a/client/v2/indexer/searchForAssets.go
+++ b/client/v2/indexer/searchForAssets.go
@@ -7,45 +7,54 @@ import (
 	"github.com/algorand/go-algorand-sdk/client/v2/common/models"
 )
 
+// SearchForAssets /v2/assets
+// Search for assets.
 type SearchForAssets struct {
 	c *Client
 	p models.SearchForAssetsParams
 }
 
+// NextToken the next page of results. Use the next token provided by the previous
+// results.
 func (s *SearchForAssets) NextToken(nextToken string) *SearchForAssets {
 	s.p.NextToken = nextToken
 	return s
 }
 
+// Limit maximum number of results to return.
 func (s *SearchForAssets) Limit(lim uint64) *SearchForAssets {
 	s.p.Limit = lim
 	return s
 }
 
+// Creator filter just assets with the given creator address.
 func (s *SearchForAssets) Creator(creator string) *SearchForAssets {
 	s.p.Creator = creator
 	return s
 }
 
+// Name filter just assets with the given name.
 func (s *SearchForAssets) Name(name string) *SearchForAssets {
 	s.p.Name = name
 	return s
 }
 
+// Unit filter just assets with the given unit.
 func (s *SearchForAssets) Unit(unit string) *SearchForAssets {
 	s.p.Unit = unit
 	return s
 }
 
+// AssetID asset ID
 func (s *SearchForAssets) AssetID(id uint64) *SearchForAssets {
 	s.p.AssetId = id
 	return s
 }
 
-func (s *SearchForAssets) Do(ctx context.Context, headers ...*common.Header) (validRound uint64, result []models.Asset, err error) {
-	var response models.AssetsResponse
-	err = s.c.get(ctx, &response, "/v2/assets", s.p, headers)
-	validRound = response.CurrentRound
-	result = response.Assets
+// Do performs HTTP request
+func (s *SearchForAssets) Do(ctx context.Context,
+	headers ...*common.Header) (response models.AssetsResponse, err error) {
+	err = s.c.get(ctx, &response,
+		"/v2/assets", s.p, headers)
 	return
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cucumber/godog v0.8.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/google/go-querystring v1.0.0
+	github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
+github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=

--- a/test/algodclientv2_test.go
+++ b/test/algodclientv2_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"path"
 
 	"github.com/algorand/go-algorand-sdk/client/v2/algod"
 	"github.com/algorand/go-algorand-sdk/client/v2/common/models"
@@ -361,4 +362,9 @@ func parsedDryrunResponseShouldHave(key string, action int) error {
 		return fmt.Errorf("action %d != %d", action, int(gd[0].Value.Action))
 	}
 	return nil
+}
+
+func mockHttpResponsesInLoadedFrom(jsonfiles, directory string) error {
+	fullPath := path.Join("./features/unit/", directory)
+	return mockHttpResponsesInLoadedFromHelper(jsonfiles, fullPath)
 }

--- a/test/algodclientv2_test.go
+++ b/test/algodclientv2_test.go
@@ -365,6 +365,6 @@ func parsedDryrunResponseShouldHave(key string, action int) error {
 }
 
 func mockHttpResponsesInLoadedFrom(jsonfiles, directory string) error {
-	fullPath := path.Join("./features/unit/", directory)
+	fullPath := path.Join("./features/resources/", directory)
 	return mockHttpResponsesInLoadedFromHelper(jsonfiles, fullPath, 0)
 }

--- a/test/algodclientv2_test.go
+++ b/test/algodclientv2_test.go
@@ -366,5 +366,5 @@ func parsedDryrunResponseShouldHave(key string, action int) error {
 
 func mockHttpResponsesInLoadedFrom(jsonfiles, directory string) error {
 	fullPath := path.Join("./features/unit/", directory)
-	return mockHttpResponsesInLoadedFromHelper(jsonfiles, fullPath)
+	return mockHttpResponsesInLoadedFromHelper(jsonfiles, fullPath, 0)
 }

--- a/test/applications_unit_test.go
+++ b/test/applications_unit_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -10,9 +11,11 @@ import (
 	"github.com/cucumber/godog"
 	"golang.org/x/crypto/ed25519"
 
+	"github.com/algorand/go-algorand-sdk/client/v2/algod"
+	"github.com/algorand/go-algorand-sdk/client/v2/indexer"
 	"github.com/algorand/go-algorand-sdk/crypto"
-	"github.com/algorand/go-algorand-sdk/mnemonic"
 	"github.com/algorand/go-algorand-sdk/future"
+	"github.com/algorand/go-algorand-sdk/mnemonic"
 	"github.com/algorand/go-algorand-sdk/types"
 )
 
@@ -165,9 +168,52 @@ func getSuggestedParams(
 	}, err
 }
 
+func weMakeAGetAssetByIDCall(assetID int) error {
+	clt, err := algod.MakeClient(mockServer.URL, "")
+	if err != nil {
+		return err
+	}
+	clt.GetAssetByID(uint64(assetID)).Do(context.Background())
+	return nil
+}
+
+func weMakeAGetApplicationByIDCall(applicationID int) error {
+	clt, err := algod.MakeClient(mockServer.URL, "")
+	if err != nil {
+		return err
+	}
+	clt.GetApplicationByID(uint64(applicationID)).Do(context.Background())
+	return nil
+}
+
+func weMakeASearchForApplicationsCall(applicationID int) error {
+	clt, err := indexer.MakeClient(mockServer.URL, "")
+	if err != nil {
+		return err
+	}
+	clt.SearchForApplications().ApplicationId(uint64(applicationID)).Do(context.Background())
+	return nil
+}
+
+func weMakeALookupApplicationsCall(applicationID int) error {
+	clt, err := indexer.MakeClient(mockServer.URL, "")
+	if err != nil {
+		return err
+	}
+	clt.LookupApplicationByID(uint64(applicationID)).Do(context.Background())
+	return nil
+}
+
 func ApplicationsUnitContext(s *godog.Suite) {
+	// @unit.transactiosn
 	s.Step(`^a signing account with address "([^"]*)" and mnemonic "([^"]*)"$`, aSigningAccountWithAddressAndMnemonic)
 	s.Step(`^I build an application transaction with operation "([^"]*)", application-id (\d+), sender "([^"]*)", approval-program "([^"]*)", clear-program "([^"]*)", global-bytes (\d+), global-ints (\d+), local-bytes (\d+), local-ints (\d+), app-args "([^"]*)", foreign-apps "([^"]*)", app-accounts "([^"]*)", fee (\d+), first-valid (\d+), last-valid (\d+), genesis-hash "([^"]*)"$`, iBuildAnApplicationTransactionUnit)
 	s.Step(`^sign the transaction$`, signTheTransaction)
 	s.Step(`^the base(\d+) encoded signed transaction should equal "([^"]*)"$`, theBaseEncodedSignedTransactionShouldEqual)
+
+	//@unit.applications
+	s.Step(`^we make a GetAssetByID call for assetID (\d+)$`, weMakeAGetAssetByIDCall)
+	s.Step(`^we make a GetApplicationByID call for applicationID (\d+)$`, weMakeAGetApplicationByIDCall)
+	s.Step(`^we make a SearchForApplications call with applicationID (\d+)$`, weMakeASearchForApplicationsCall)
+	s.Step(`^we make a LookupApplications call with applicationID (\d+)$`, weMakeALookupApplicationsCall)
 }

--- a/test/docker/run_docker.sh
+++ b/test/docker/run_docker.sh
@@ -5,7 +5,7 @@ set -e
 # reset test harness
 rm -rf test-harness
 rm -rf test/features
-git clone --single-branch --branch develop https://github.com/algorand/algorand-sdk-testing.git test-harness
+git clone --single-branch --branch master https://github.com/algorand/algorand-sdk-testing.git test-harness
 #copy feature files into project
 mv test-harness/features test/features
 

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -18,7 +18,7 @@ func loadMockJsons(commaDelimitedFilenames, pathToJsons string) ([][]byte, error
 	jsonFilenames := strings.Split(commaDelimitedFilenames, ",")
 	var bytesArray [][]byte
 	for _, jsonFilename := range jsonFilenames {
-		fullPath := path.Join("./features/unit/", pathToJsons, jsonFilename)
+		fullPath := path.Join(pathToJsons, jsonFilename)
 		jsonfile, err := os.Open(fullPath)
 		if err != nil {
 			return nil, err
@@ -44,7 +44,7 @@ func loadMockJsons(commaDelimitedFilenames, pathToJsons string) ([][]byte, error
 var mockServer *httptest.Server
 var responseRing *ring.Ring
 
-func mockHttpResponsesInLoadedFrom(jsonfiles, directory string) error {
+func mockHttpResponsesInLoadedFromHelper(jsonfiles, directory string) error {
 	jsons, err := loadMockJsons(jsonfiles, directory)
 	if err != nil {
 		return err

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -44,7 +44,7 @@ func loadMockJsons(commaDelimitedFilenames, pathToJsons string) ([][]byte, error
 var mockServer *httptest.Server
 var responseRing *ring.Ring
 
-func mockHttpResponsesInLoadedFromHelper(jsonfiles, directory string) error {
+func mockHttpResponsesInLoadedFromHelper(jsonfiles, directory string, status int) error {
 	jsons, err := loadMockJsons(jsonfiles, directory)
 	if err != nil {
 		return err
@@ -56,6 +56,9 @@ func mockHttpResponsesInLoadedFromHelper(jsonfiles, directory string) error {
 	}
 	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json := responseRing.Value.([]byte)
+		if status > 0 {
+			w.WriteHeader(status)
+		}
 		_, err = w.Write(json)
 		responseRing = responseRing.Next()
 	}))

--- a/test/indexer_integration_test.go
+++ b/test/indexer_integration_test.go
@@ -521,8 +521,8 @@ var indexerSearchForAssetsResponse []models.Asset
 
 func iUseToSearchForAssetsWithAndToken(clientNum, zero, assetId int, creator, name, unit, token string) error {
 	ic := indexerClients[clientNum]
-	var err error
-	_, indexerSearchForAssetsResponse, err = ic.SearchForAssets().AssetID(uint64(assetId)).Creator(creator).Name(name).Unit(unit).NextToken(token).Do(context.Background())
+	resp, err := ic.SearchForAssets().AssetID(uint64(assetId)).Creator(creator).Name(name).Unit(unit).NextToken(token).Do(context.Background())
+	indexerSearchForAssetsResponse = resp.Assets
 	return err
 }
 

--- a/test/indexer_unit_test.go
+++ b/test/indexer_unit_test.go
@@ -310,7 +310,11 @@ func weMakeAnySearchForAssetsCall() error {
 	if err != nil {
 		return err
 	}
-	responseValidRound, searchAssetsResponse, globalErrForExamination = indexerClient.SearchForAssets().Do(context.Background())
+	var resp models.AssetsResponse
+	resp, globalErrForExamination = indexerClient.SearchForAssets().Do(context.Background())
+	responseValidRound = resp.CurrentRound
+	searchAssetsResponse = resp.Assets
+
 	return nil
 }
 
@@ -473,7 +477,7 @@ func weMakeASearchForAssetsCallWithLimitCreatorNameUnitIndexAndAfterAsset(limit 
 	if err != nil {
 		return err
 	}
-	_, _, globalErrForExamination = indexerClient.SearchForAssets().AssetID(uint64(assetIndex)).Limit(uint64(limit)).Creator(creator).Name(name).Unit(unit).Do(context.Background())
+	_, globalErrForExamination = indexerClient.SearchForAssets().AssetID(uint64(assetIndex)).Limit(uint64(limit)).Creator(creator).Name(name).Unit(unit).Do(context.Background())
 	return nil
 }
 

--- a/test/responses_unit_test.go
+++ b/test/responses_unit_test.go
@@ -2,42 +2,57 @@ package test
 
 import (
 	"context"
+	baseJson "encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"path"
-	
+	"reflect"
+
 	"github.com/cucumber/godog"
 
 	"github.com/algorand/go-algorand-sdk/client/v2/algod"
-	"github.com/algorand/go-algorand-sdk/client/v2/indexer"	
+	"github.com/algorand/go-algorand-sdk/client/v2/common/models"
+	"github.com/algorand/go-algorand-sdk/client/v2/indexer"
+	"github.com/algorand/go-algorand-sdk/encoding/json"
 )
 
 var algodC *algod.Client
 var indexerC *indexer.Client
+var baselinePath string
+var expectedStatus int
+var response interface{}
 
 func mockHttpResponsesInLoadedFromWithStatus(
 	jsonfile, loadedFrom /* generated_responses*/ string, status int) error {
 	directory := path.Join("./features/resources/", loadedFrom)
+	baselinePath = path.Join(directory, jsonfile)
 	var err error
-	err = mockHttpResponsesInLoadedFromHelper(jsonfile, directory)
+	expectedStatus = status
+	err = mockHttpResponsesInLoadedFromHelper(jsonfile, directory, status)
 	if err != nil {
 		return err
 	}
 	algodC, err = algod.MakeClient(mockServer.URL, "")
-		if err != nil {
+	if err != nil {
 		return err
 	}
 	indexerC, err = indexer.MakeClient(mockServer.URL, "")
 	return err
 }
 
-var response interface{}
-
 func weMakeAnyCallTo(client /* algod/indexer */, endpoint string) (err error) {
+	var round uint64
+	var something interface{}
 	switch client {
 	case "indexer":
 		switch endpoint {
 		case "lookupAccountByID":
-			_, response, err = indexerC.LookupAccountByID("").Do(context.Background())
+			round, something, err = indexerC.LookupAccountByID("").Do(context.Background())
+			response = models.LookupAccountByIDResponse{
+				CurrentRound: round,
+				Account:      something.(models.Account),
+			}
 		case "searchForAccounts":
 			response, err = indexerC.SearchAccounts().Do(context.Background())
 		case "lookupApplicationByID":
@@ -47,9 +62,17 @@ func weMakeAnyCallTo(client /* algod/indexer */, endpoint string) (err error) {
 		case "lookupAssetBalances":
 			response, err = indexerC.LookupAssetBalances(10).Do(context.Background())
 		case "lookupAssetByID":
-			_, response, err = indexerC.LookupAssetByID(10).Do(context.Background())
+			round, something, err = indexerC.LookupAssetByID(10).Do(context.Background())
+			response = models.LookupAssetByIDResponse{
+				CurrentRound: round,
+				Asset:        something.(models.Asset),
+			}
 		case "searchForAssets":
-			_, response, err = indexerC.SearchForAssets().Do(context.Background())
+			round, something, err = indexerC.SearchForAssets().Do(context.Background())
+			response = models.AssetsResponse{
+				Assets:       something.([]models.Asset),
+				CurrentRound: round,
+			}
 		case "lookupAccountTransactions":
 			response, err = indexerC.LookupAccountTransactions("").Do(context.Background())
 		case "lookupAssetTransactions":
@@ -57,26 +80,45 @@ func weMakeAnyCallTo(client /* algod/indexer */, endpoint string) (err error) {
 		case "searchForTransactions":
 			response, err = indexerC.SearchForTransactions().Do(context.Background())
 		default:
-			fmt.Errorf("unknown endpoint: %s", endpoint)
+			err = fmt.Errorf("unknown endpoint: %s", endpoint)
 		}
 		/*	case "algod":
-		switch endpoint {
-		case "GetStatus                
-		case "WaitForBlock             
-		case "TealCompile              
-		case "RawTransaction           
-		case "GetSupply                
-		case "TransactionParams        
-		case "GetApplicationByID       
-		case "GetAssetByID
-		default:
-		}*/
+			switch endpoint {
+			case "GetStatus
+			case "WaitForBlock
+			case "TealCompile
+			case "RawTransaction
+			case "GetSupply
+			case "TransactionParams
+			case "GetApplicationByID
+			case "GetAssetByID
+			default:
+			}*/
 	}
 	return err
 }
 
 func theParsedResponseShouldEqualTheMockResponse() error {
-	return godog.ErrPending
+	var err error
+
+	responseJson := string(json.Encode(response))
+
+	jsonfile, err := os.Open(baselinePath)
+	if err != nil {
+		return err
+	}
+	fileBytes, err := ioutil.ReadAll(jsonfile)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("sss_sss_E____%s\n ", responseJson)
+	fmt.Printf("sss_sss_baseline____%s\n ", string(fileBytes))
+
+	ans, err := EqualJson(string(fileBytes), responseJson)
+
+	fmt.Printf("sss_sss_F____ %v\n", ans)
+
+	return err
 }
 
 func ResponsesContext(s *godog.Suite) {
@@ -84,24 +126,42 @@ func ResponsesContext(s *godog.Suite) {
 	s.Step(`^we make any "([^"]*)" call to "([^"]*)"\.$`, weMakeAnyCallTo)
 	s.Step(`^the parsed response should equal the mock response\.$`, theParsedResponseShouldEqualTheMockResponse)
 }
+
 /*
-      | indexer_applications_AccountResponse_0.json             | 200    | indexer |  |
-      | indexer_applications_AccountsResponse_0.json            | 200    | indexer |  |
-      | indexer_applications_ApplicationResponse_0.json         | 200    | indexer |  |
-      | indexer_applications_ApplicationsResponse_0.json        | 200    | indexer |  |
-      | indexer_applications_AssetBalancesResponse_0.json       | 200    | indexer |  |
-      | indexer_applications_AssetResponse_0.json               | 200    | indexer |  |
-      | indexer_applications_AssetsResponse_0.json              | 200    | indexer |  |
-      | indexer_applications_TransactionsResponse_0.json        | 200    | indexer |  |
-      | indexer_applications_TransactionsResponse_0.json        | 200    | indexer |  |
-      | indexer_applications_TransactionsResponse_0.json        | 200    | indexer |  |
-      | indexer_applications_ErrorResponse_0.json               | 500    | indexer |  |
-      | algod_applications_NodeStatusResponse_0.json            | 200    | algod   |  |
-      | algod_applications_NodeStatusResponse_0.json            | 200    | algod   |  |
-      | algod_applications_CompileResponse_0.json               | 200    | algod   |  |
-      | algod_applications_PostTransactionsResponse_0.json      | 200    | algod   |  |
-      | algod_applications_SupplyResponse_0.json                | 200    | algod   |  |
-      | algod_applications_TransactionParametersResponse_0.json | 200    | algod   |  |
-      | algod_applications_ApplicationResponse_0.json           | 200    | algod   |  |
-      | algod_applications_AssetResponse_0.json                 | 200    | algod   |  |
+   | indexer_applications_AccountResponse_0.json             | 200    | indexer |  |
+   | indexer_applications_AccountsResponse_0.json            | 200    | indexer |  |
+   | indexer_applications_ApplicationResponse_0.json         | 200    | indexer |  |
+   | indexer_applications_ApplicationsResponse_0.json        | 200    | indexer |  |
+   | indexer_applications_AssetBalancesResponse_0.json       | 200    | indexer |  |
+   | indexer_applications_AssetResponse_0.json               | 200    | indexer |  |
+   | indexer_applications_AssetsResponse_0.json              | 200    | indexer |  |
+   | indexer_applications_TransactionsResponse_0.json        | 200    | indexer |  |
+   | indexer_applications_TransactionsResponse_0.json        | 200    | indexer |  |
+   | indexer_applications_TransactionsResponse_0.json        | 200    | indexer |  |
+   | indexer_applications_ErrorResponse_0.json               | 500    | indexer |  |
+   | algod_applications_NodeStatusResponse_0.json            | 200    | algod   |  |
+   | algod_applications_NodeStatusResponse_0.json            | 200    | algod   |  |
+   | algod_applications_CompileResponse_0.json               | 200    | algod   |  |
+   | algod_applications_PostTransactionsResponse_0.json      | 200    | algod   |  |
+   | algod_applications_SupplyResponse_0.json                | 200    | algod   |  |
+   | algod_applications_TransactionParametersResponse_0.json | 200    | algod   |  |
+   | algod_applications_ApplicationResponse_0.json           | 200    | algod   |  |
+   | algod_applications_AssetResponse_0.json                 | 200    | algod   |  |
 */
+
+func EqualJson(j1, j2 string) (ans bool, err error) {
+
+	var o1 interface{}
+	var o2 interface{}
+	err = baseJson.Unmarshal([]byte(j1), &o1)
+	if err != nil {
+		return false, err
+	}
+	err = baseJson.Unmarshal([]byte(j2), &o2)
+	if err != nil {
+		return false, err
+	}
+
+	//	reflect.
+	return reflect.DeepEqual(o1, o2), nil
+}

--- a/test/responses_unit_test.go
+++ b/test/responses_unit_test.go
@@ -202,7 +202,7 @@ func EqualJson(j1, j2 string) (ans bool, err error) {
 			if strings.Contains(line, "false") {
 				continue
 			}
-			err = fmt.Errorf(line)
+			err = fmt.Errorf(str)
 			return false, err
 		}
 		if strings.Contains(line, "___ADDED___") {

--- a/test/responses_unit_test.go
+++ b/test/responses_unit_test.go
@@ -202,7 +202,7 @@ func EqualJson(j1, j2 string) (ans bool, err error) {
 			if strings.Contains(line, "false") {
 				continue
 			}
-			err = fmt.Errorf(str)
+			err = fmt.Errorf(line)
 			return false, err
 		}
 		if strings.Contains(line, "___ADDED___") {

--- a/test/responses_unit_test.go
+++ b/test/responses_unit_test.go
@@ -140,8 +140,12 @@ func theParsedResponseShouldEqualTheMockResponse() error {
 		responseJson = response.(error).Error()
 		// The error message is not a well formed Json.
 		// Verify the expected status code, and remove the json corrupting message
-		extraTxt := fmt.Sprintf("HTTP %d Internal Server Error:", expectedStatus)
-		responseJson = strings.ReplaceAll(responseJson, extraTxt, "")
+		statusCode := fmt.Sprintf("%d", expectedStatus)
+		if !strings.Contains(responseJson, statusCode) {
+			return fmt.Errorf("Expected error code: %d, got otherwise", expectedStatus)
+		}
+		parts := strings.SplitAfterN(responseJson, ":", 2)
+		responseJson = parts[1]
 	} else {
 		responseJson = string(json.Encode(response))
 	}

--- a/test/responses_unit_test.go
+++ b/test/responses_unit_test.go
@@ -182,8 +182,14 @@ func ResponsesContext(s *godog.Suite) {
 	s.Step(`^the parsed response should equal the mock response\.$`, theParsedResponseShouldEqualTheMockResponse)
 }
 
+// EqualJson compares two json strings.
+// returns true if considered equal, false otherwise.
+// The error returns the difference.
+// For reference: j1 is the baseline, j2 is the test
 func EqualJson(j1, j2 string) (ans bool, err error) {
 
+	// This func uses jsondiff.
+	// options configures it.
 	options := jsondiff.Options{
 		Added:            jsondiff.Tag{Begin: "___ADDED___", End: ""},
 		Removed:          jsondiff.Tag{Begin: "___REMED___", End: ""},
@@ -192,28 +198,41 @@ func EqualJson(j1, j2 string) (ans bool, err error) {
 	}
 	options.PrintTypes = false
 	d, str := jsondiff.Compare([]byte(j1), []byte(j2), &options)
+	// If fully match, return true
 	if d == jsondiff.FullMatch {
 		return true, nil
 	}
+
+	// Check the difference, and decide if it is still accepted as "equal"
+	// Scan line by line, and examine the difference
 	scanner := bufio.NewScanner(strings.NewReader(str))
 	for scanner.Scan() {
 		line := scanner.Text()
+		// If baseline has the property (j1), but the test (j2) has it removed
 		if strings.Contains(line, "___REMED___") {
+			// If the value of the property is false, then accept it
+			// The default value is false. Missing property is considered as false
 			if strings.Contains(line, "false") {
 				continue
 			}
+			// Any other ommision will not be considered as equal
 			err = fmt.Errorf(line)
 			return false, err
 		}
+		// If the test has properties not found in the baseline, then they are not equal
 		if strings.Contains(line, "___ADDED___") {
 			err = fmt.Errorf(line)
 			return false, err
 		}
+		// If the properties are different, they they are not equal
 		if strings.Contains(line, "___DIFFER___") {
 			err = fmt.Errorf(line)
 			return false, err
 		}
 	}
+	// Extra layer of check. This is not expected to be true.
+	// If only difference is removed with false value property, then the difference
+	// will be qualified as SupersetMatch. If not, should be be considered equal.
 	if d != jsondiff.SupersetMatch {
 		err = fmt.Errorf(str)
 		return false, err

--- a/test/responses_unit_test.go
+++ b/test/responses_unit_test.go
@@ -1,0 +1,107 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"path"
+	
+	"github.com/cucumber/godog"
+
+	"github.com/algorand/go-algorand-sdk/client/v2/algod"
+	"github.com/algorand/go-algorand-sdk/client/v2/indexer"	
+)
+
+var algodC *algod.Client
+var indexerC *indexer.Client
+
+func mockHttpResponsesInLoadedFromWithStatus(
+	jsonfile, loadedFrom /* generated_responses*/ string, status int) error {
+	directory := path.Join("./features/resources/", loadedFrom)
+	var err error
+	err = mockHttpResponsesInLoadedFromHelper(jsonfile, directory)
+	if err != nil {
+		return err
+	}
+	algodC, err = algod.MakeClient(mockServer.URL, "")
+		if err != nil {
+		return err
+	}
+	indexerC, err = indexer.MakeClient(mockServer.URL, "")
+	return err
+}
+
+var response interface{}
+
+func weMakeAnyCallTo(client /* algod/indexer */, endpoint string) (err error) {
+	switch client {
+	case "indexer":
+		switch endpoint {
+		case "lookupAccountByID":
+			_, response, err = indexerC.LookupAccountByID("").Do(context.Background())
+		case "searchForAccounts":
+			response, err = indexerC.SearchAccounts().Do(context.Background())
+		case "lookupApplicationByID":
+			response, err = indexerC.LookupApplicationByID(10).Do(context.Background())
+		case "searchForApplications":
+			response, err = indexerC.SearchForApplications().Do(context.Background())
+		case "lookupAssetBalances":
+			response, err = indexerC.LookupAssetBalances(10).Do(context.Background())
+		case "lookupAssetByID":
+			_, response, err = indexerC.LookupAssetByID(10).Do(context.Background())
+		case "searchForAssets":
+			_, response, err = indexerC.SearchForAssets().Do(context.Background())
+		case "lookupAccountTransactions":
+			response, err = indexerC.LookupAccountTransactions("").Do(context.Background())
+		case "lookupAssetTransactions":
+			response, err = indexerC.LookupAssetTransactions(10).Do(context.Background())
+		case "searchForTransactions":
+			response, err = indexerC.SearchForTransactions().Do(context.Background())
+		default:
+			fmt.Errorf("unknown endpoint: %s", endpoint)
+		}
+		/*	case "algod":
+		switch endpoint {
+		case "GetStatus                
+		case "WaitForBlock             
+		case "TealCompile              
+		case "RawTransaction           
+		case "GetSupply                
+		case "TransactionParams        
+		case "GetApplicationByID       
+		case "GetAssetByID
+		default:
+		}*/
+	}
+	return err
+}
+
+func theParsedResponseShouldEqualTheMockResponse() error {
+	return godog.ErrPending
+}
+
+func ResponsesContext(s *godog.Suite) {
+	s.Step(`^mock http responses in "([^"]*)" loaded from "([^"]*)" with status (\d+)\.$`, mockHttpResponsesInLoadedFromWithStatus)
+	s.Step(`^we make any "([^"]*)" call to "([^"]*)"\.$`, weMakeAnyCallTo)
+	s.Step(`^the parsed response should equal the mock response\.$`, theParsedResponseShouldEqualTheMockResponse)
+}
+/*
+      | indexer_applications_AccountResponse_0.json             | 200    | indexer |  |
+      | indexer_applications_AccountsResponse_0.json            | 200    | indexer |  |
+      | indexer_applications_ApplicationResponse_0.json         | 200    | indexer |  |
+      | indexer_applications_ApplicationsResponse_0.json        | 200    | indexer |  |
+      | indexer_applications_AssetBalancesResponse_0.json       | 200    | indexer |  |
+      | indexer_applications_AssetResponse_0.json               | 200    | indexer |  |
+      | indexer_applications_AssetsResponse_0.json              | 200    | indexer |  |
+      | indexer_applications_TransactionsResponse_0.json        | 200    | indexer |  |
+      | indexer_applications_TransactionsResponse_0.json        | 200    | indexer |  |
+      | indexer_applications_TransactionsResponse_0.json        | 200    | indexer |  |
+      | indexer_applications_ErrorResponse_0.json               | 500    | indexer |  |
+      | algod_applications_NodeStatusResponse_0.json            | 200    | algod   |  |
+      | algod_applications_NodeStatusResponse_0.json            | 200    | algod   |  |
+      | algod_applications_CompileResponse_0.json               | 200    | algod   |  |
+      | algod_applications_PostTransactionsResponse_0.json      | 200    | algod   |  |
+      | algod_applications_SupplyResponse_0.json                | 200    | algod   |  |
+      | algod_applications_TransactionParametersResponse_0.json | 200    | algod   |  |
+      | algod_applications_ApplicationResponse_0.json           | 200    | algod   |  |
+      | algod_applications_AssetResponse_0.json                 | 200    | algod   |  |
+*/

--- a/test/steps_test.go
+++ b/test/steps_test.go
@@ -151,6 +151,7 @@ func TestMain(m *testing.M) {
 		IndexerIntegrationTestContext(s)
 		ApplicationsContext(s)
 		ApplicationsUnitContext(s)
+		ResponsesContext(s)
 	}, opt)
 
 	if st := m.Run(); st > status {


### PR DESCRIPTION
Added responses and path unit tests. 

Dependency added:
github.com/nsf/jsondiff for comparing json structures

Changes to test helpers:
* Updated mock http responses helper to accept status code
* Implemented EqualJson method to compare json files and not complain about missing default(false) valued fields

Changes to new apis:
* Catchpoint responses added to NodeStatus
* Application fields added to various response models

changes to existing apis:
* Removed HasSyncedSinceStartup bool `json:"has-synced-since-startup from NodeStatus
* SearchForAssets should return models.AssetsResponse otherwise, missing next-token
* Added AuthAddr string `json:"auth-addr,omitempty"` to Transaction in response models.go
* Added IntraRoundOffset uint64 `json:"intra-round-offset,omitempty"` to Transaction in response models.go (is this new?)
* Some existing tests updated due to the SearchForAssets change

Fixed the type of TealPrograms to []byte (was string)