### PR TITLE
Update travis.yml to `make lint` before make `docker-test`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ install:
   - go get -u golang.org/x/lint/golint
 
 script:
+  - make lint
   - make docker-test


### PR DESCRIPTION
# Summary
Our other `go` repositories enforce `golint`, but this one does not yet. As such, we have accumulated many warnings. This PR proposes to enforce `golint` through Travis.

## Testing
As this is a travis-related change, leaning on travis to test this.

## See also
Closes #168 