### PR TITLE
Regenerate response models and clients from spec

### DIFF
--- a/client/v2/algod/algod.go
+++ b/client/v2/algod/algod.go
@@ -40,6 +40,8 @@ func MakeClient(address string, apiToken string) (c *Client, err error) {
 	return
 }
 
+// MakeClientWithHeaders is the factory for constructing a ClientV2 for a
+// given endpoint with custom headers.
 func MakeClientWithHeaders(address string, apiToken string, headers []*common.Header) (c *Client, err error) {
 	commonClientWithHeaders, err := common.MakeClientWithHeaders(address, authHeader, apiToken, headers)
 	c = (*Client)(commonClientWithHeaders)

--- a/client/v2/common/models/account.go
+++ b/client/v2/common/models/account.go
@@ -5,18 +5,22 @@ package models
 // data/basics/userBalance.go : AccountData
 type Account struct {
 	// Address the account public key
-	Address string `json:"address,omitempty"`
+	Address string `json:"address"`
 
 	// Amount (algo) total number of MicroAlgos in the account
-	Amount uint64 `json:"amount,omitempty"`
+	Amount uint64 `json:"amount"`
 
 	// AmountWithoutPendingRewards specifies the amount of MicroAlgos in the account,
 	// without the pending rewards.
-	AmountWithoutPendingRewards uint64 `json:"amount-without-pending-rewards,omitempty"`
+	AmountWithoutPendingRewards uint64 `json:"amount-without-pending-rewards"`
 
 	// AppsLocalState (appl) applications local data stored in this account.
 	// Note the raw object uses `map[int] -> AppLocalState` for this type.
 	AppsLocalState []ApplicationLocalState `json:"apps-local-state,omitempty"`
+
+	// AppsTotalExtraPages (teap) the sum of all extra application program pages for
+	// this account.
+	AppsTotalExtraPages uint64 `json:"apps-total-extra-pages,omitempty"`
 
 	// AppsTotalSchema (tsch) stores the sum of all of the local schemas and global
 	// schemas in this account.
@@ -55,7 +59,7 @@ type Account struct {
 	Participation AccountParticipation `json:"participation,omitempty"`
 
 	// PendingRewards amount of MicroAlgos of pending rewards in this account.
-	PendingRewards uint64 `json:"pending-rewards,omitempty"`
+	PendingRewards uint64 `json:"pending-rewards"`
 
 	// RewardBase (ebase) used as part of the rewards computation. Only applicable to
 	// accounts which are participating.
@@ -63,10 +67,10 @@ type Account struct {
 
 	// Rewards (ern) total rewards of MicroAlgos the account has received, including
 	// pending rewards.
-	Rewards uint64 `json:"rewards,omitempty"`
+	Rewards uint64 `json:"rewards"`
 
 	// Round the round for which this information is relevant.
-	Round uint64 `json:"round,omitempty"`
+	Round uint64 `json:"round"`
 
 	// SigType indicates what type of signature is used by this account, must be one
 	// of:
@@ -81,5 +85,5 @@ type Account struct {
 	// pool.
 	// * NotParticipating - indicates that the associated account is neither a
 	// delegator nor a delegate.
-	Status string `json:"status,omitempty"`
+	Status string `json:"status"`
 }

--- a/client/v2/common/models/account_participation.go
+++ b/client/v2/common/models/account_participation.go
@@ -5,18 +5,18 @@ package models
 type AccountParticipation struct {
 	// SelectionParticipationKey (sel) Selection public key (if any) currently
 	// registered for this round.
-	SelectionParticipationKey []byte `json:"selection-participation-key,omitempty"`
+	SelectionParticipationKey []byte `json:"selection-participation-key"`
 
 	// VoteFirstValid (voteFst) First round for which this participation is valid.
-	VoteFirstValid uint64 `json:"vote-first-valid,omitempty"`
+	VoteFirstValid uint64 `json:"vote-first-valid"`
 
 	// VoteKeyDilution (voteKD) Number of subkeys in each batch of participation keys.
-	VoteKeyDilution uint64 `json:"vote-key-dilution,omitempty"`
+	VoteKeyDilution uint64 `json:"vote-key-dilution"`
 
 	// VoteLastValid (voteLst) Last round for which this participation is valid.
-	VoteLastValid uint64 `json:"vote-last-valid,omitempty"`
+	VoteLastValid uint64 `json:"vote-last-valid"`
 
 	// VoteParticipationKey (vote) root participation public key (if any) currently
 	// registered for this round.
-	VoteParticipationKey []byte `json:"vote-participation-key,omitempty"`
+	VoteParticipationKey []byte `json:"vote-participation-key"`
 }

--- a/client/v2/common/models/account_response.go
+++ b/client/v2/common/models/account_response.go
@@ -5,8 +5,8 @@ type AccountResponse struct {
 	// Account account information at a given round.
 	// Definition:
 	// data/basics/userBalance.go : AccountData
-	Account Account `json:"account,omitempty"`
+	Account Account `json:"account"`
 
 	// CurrentRound round at which the results were computed.
-	CurrentRound uint64 `json:"current-round,omitempty"`
+	CurrentRound uint64 `json:"current-round"`
 }

--- a/client/v2/common/models/account_state_delta.go
+++ b/client/v2/common/models/account_state_delta.go
@@ -3,8 +3,8 @@ package models
 // AccountStateDelta application state delta.
 type AccountStateDelta struct {
 	// Address
-	Address string `json:"address,omitempty"`
+	Address string `json:"address"`
 
 	// Delta application state delta.
-	Delta []EvalDeltaKeyValue `json:"delta,omitempty"`
+	Delta []EvalDeltaKeyValue `json:"delta"`
 }

--- a/client/v2/common/models/accounts_response.go
+++ b/client/v2/common/models/accounts_response.go
@@ -3,10 +3,10 @@ package models
 // AccountsResponse
 type AccountsResponse struct {
 	// Accounts
-	Accounts []Account `json:"accounts,omitempty"`
+	Accounts []Account `json:"accounts"`
 
 	// CurrentRound round at which the results were computed.
-	CurrentRound uint64 `json:"current-round,omitempty"`
+	CurrentRound uint64 `json:"current-round"`
 
 	// NextToken used for pagination, when making another request provide this token
 	// with the next parameter.

--- a/client/v2/common/models/application.go
+++ b/client/v2/common/models/application.go
@@ -12,8 +12,8 @@ type Application struct {
 	DeletedAtRound uint64 `json:"deleted-at-round,omitempty"`
 
 	// Id (appidx) application index.
-	Id uint64 `json:"id,omitempty"`
+	Id uint64 `json:"id"`
 
 	// Params (appparams) application parameters.
-	Params ApplicationParams `json:"params,omitempty"`
+	Params ApplicationParams `json:"params"`
 }

--- a/client/v2/common/models/application_local_state.go
+++ b/client/v2/common/models/application_local_state.go
@@ -10,7 +10,7 @@ type ApplicationLocalState struct {
 	Deleted bool `json:"deleted,omitempty"`
 
 	// Id the application which this local state is for.
-	Id uint64 `json:"id,omitempty"`
+	Id uint64 `json:"id"`
 
 	// KeyValue (tkv) storage.
 	KeyValue []TealKeyValue `json:"key-value,omitempty"`
@@ -19,5 +19,5 @@ type ApplicationLocalState struct {
 	OptedInAtRound uint64 `json:"opted-in-at-round,omitempty"`
 
 	// Schema (hsch) schema.
-	Schema ApplicationStateSchema `json:"schema,omitempty"`
+	Schema ApplicationStateSchema `json:"schema"`
 }

--- a/client/v2/common/models/application_params.go
+++ b/client/v2/common/models/application_params.go
@@ -3,14 +3,17 @@ package models
 // ApplicationParams stores the global information associated with an application.
 type ApplicationParams struct {
 	// ApprovalProgram (approv) approval program.
-	ApprovalProgram []byte `json:"approval-program,omitempty"`
+	ApprovalProgram []byte `json:"approval-program"`
 
 	// ClearStateProgram (clearp) approval program.
-	ClearStateProgram []byte `json:"clear-state-program,omitempty"`
+	ClearStateProgram []byte `json:"clear-state-program"`
 
 	// Creator the address that created this application. This is the address where the
 	// parameters and global state for this application can be found.
 	Creator string `json:"creator,omitempty"`
+
+	// ExtraProgramPages (epp) the amount of extra program pages available to this app.
+	ExtraProgramPages uint64 `json:"extra-program-pages,omitempty"`
 
 	// GlobalState [\gs) global schema
 	GlobalState []TealKeyValue `json:"global-state,omitempty"`
@@ -20,7 +23,4 @@ type ApplicationParams struct {
 
 	// LocalStateSchema [\lsch) local schema
 	LocalStateSchema ApplicationStateSchema `json:"local-state-schema,omitempty"`
-
-	// ExtraPages (extrapages) extra length needed for application programs
-	ExtraPages int `json:"extra-pages,omitempty"`
 }

--- a/client/v2/common/models/application_response.go
+++ b/client/v2/common/models/application_response.go
@@ -6,5 +6,5 @@ type ApplicationResponse struct {
 	Application Application `json:"application,omitempty"`
 
 	// CurrentRound round at which the results were computed.
-	CurrentRound uint64 `json:"current-round,omitempty"`
+	CurrentRound uint64 `json:"current-round"`
 }

--- a/client/v2/common/models/application_state_schema.go
+++ b/client/v2/common/models/application_state_schema.go
@@ -4,8 +4,8 @@ package models
 // stored.
 type ApplicationStateSchema struct {
 	// NumByteSlice (nbs) num of byte slices.
-	NumByteSlice uint64 `json:"num-byte-slice,omitempty"`
+	NumByteSlice uint64 `json:"num-byte-slice"`
 
 	// NumUint (nui) num of uints.
-	NumUint uint64 `json:"num-uint,omitempty"`
+	NumUint uint64 `json:"num-uint"`
 }

--- a/client/v2/common/models/applications_response.go
+++ b/client/v2/common/models/applications_response.go
@@ -3,10 +3,10 @@ package models
 // ApplicationsResponse
 type ApplicationsResponse struct {
 	// Applications
-	Applications []Application `json:"applications,omitempty"`
+	Applications []Application `json:"applications"`
 
 	// CurrentRound round at which the results were computed.
-	CurrentRound uint64 `json:"current-round,omitempty"`
+	CurrentRound uint64 `json:"current-round"`
 
 	// NextToken used for pagination, when making another request provide this token
 	// with the next parameter.

--- a/client/v2/common/models/asset.go
+++ b/client/v2/common/models/asset.go
@@ -12,11 +12,11 @@ type Asset struct {
 	DestroyedAtRound uint64 `json:"destroyed-at-round,omitempty"`
 
 	// Index unique asset identifier
-	Index uint64 `json:"index,omitempty"`
+	Index uint64 `json:"index"`
 
 	// Params assetParams specifies the parameters for an asset.
 	// (apar) when part of an AssetConfig transaction.
 	// Definition:
 	// data/transactions/asset.go : AssetParams
-	Params AssetParams `json:"params,omitempty"`
+	Params AssetParams `json:"params"`
 }

--- a/client/v2/common/models/asset_balances_response.go
+++ b/client/v2/common/models/asset_balances_response.go
@@ -3,10 +3,10 @@ package models
 // AssetBalancesResponse
 type AssetBalancesResponse struct {
 	// Balances
-	Balances []MiniAssetHolding `json:"balances,omitempty"`
+	Balances []MiniAssetHolding `json:"balances"`
 
 	// CurrentRound round at which the results were computed.
-	CurrentRound uint64 `json:"current-round,omitempty"`
+	CurrentRound uint64 `json:"current-round"`
 
 	// NextToken used for pagination, when making another request provide this token
 	// with the next parameter.

--- a/client/v2/common/models/asset_holding.go
+++ b/client/v2/common/models/asset_holding.go
@@ -5,21 +5,21 @@ package models
 // data/basics/userBalance.go : AssetHolding
 type AssetHolding struct {
 	// Amount (a) number of units held.
-	Amount uint64 `json:"amount,omitempty"`
+	Amount uint64 `json:"amount"`
 
 	// AssetId asset ID of the holding.
-	AssetId uint64 `json:"asset-id,omitempty"`
+	AssetId uint64 `json:"asset-id"`
 
 	// Creator address that created this asset. This is the address where the
 	// parameters for this asset can be found, and also the address where unwanted
 	// asset units can be sent in the worst case.
-	Creator string `json:"creator,omitempty"`
+	Creator string `json:"creator"`
 
 	// Deleted whether or not the asset holding is currently deleted from its account.
 	Deleted bool `json:"deleted,omitempty"`
 
 	// IsFrozen (f) whether or not the holding is frozen.
-	IsFrozen bool `json:"is-frozen,omitempty"`
+	IsFrozen bool `json:"is-frozen"`
 
 	// OptedInAtRound round during which the account opted into this asset holding.
 	OptedInAtRound uint64 `json:"opted-in-at-round,omitempty"`

--- a/client/v2/common/models/asset_params.go
+++ b/client/v2/common/models/asset_params.go
@@ -12,13 +12,13 @@ type AssetParams struct {
 	// Creator the address that created this asset. This is the address where the
 	// parameters for this asset can be found, and also the address where unwanted
 	// asset units can be sent in the worst case.
-	Creator string `json:"creator,omitempty"`
+	Creator string `json:"creator"`
 
 	// Decimals (dc) The number of digits to use after the decimal point when
 	// displaying this asset. If 0, the asset is not divisible. If 1, the base unit of
 	// the asset is in tenths. If 2, the base unit of the asset is in hundredths, and
 	// so on. This value must be between 0 and 19 (inclusive).
-	Decimals uint64 `json:"decimals,omitempty"`
+	Decimals uint64 `json:"decimals"`
 
 	// DefaultFrozen (df) Whether holdings of this asset are frozen by default.
 	DefaultFrozen bool `json:"default-frozen,omitempty"`
@@ -42,7 +42,7 @@ type AssetParams struct {
 	Reserve string `json:"reserve,omitempty"`
 
 	// Total (t) The total number of units of this asset.
-	Total uint64 `json:"total,omitempty"`
+	Total uint64 `json:"total"`
 
 	// UnitName (un) Name of a unit of this asset, as supplied by the creator.
 	UnitName string `json:"unit-name,omitempty"`

--- a/client/v2/common/models/asset_response.go
+++ b/client/v2/common/models/asset_response.go
@@ -3,8 +3,8 @@ package models
 // AssetResponse
 type AssetResponse struct {
 	// Asset specifies both the unique identifier and the parameters for an asset
-	Asset Asset `json:"asset,omitempty"`
+	Asset Asset `json:"asset"`
 
 	// CurrentRound round at which the results were computed.
-	CurrentRound uint64 `json:"current-round,omitempty"`
+	CurrentRound uint64 `json:"current-round"`
 }

--- a/client/v2/common/models/assets_response.go
+++ b/client/v2/common/models/assets_response.go
@@ -3,10 +3,10 @@ package models
 // AssetsResponse
 type AssetsResponse struct {
 	// Assets
-	Assets []Asset `json:"assets,omitempty"`
+	Assets []Asset `json:"assets"`
 
 	// CurrentRound round at which the results were computed.
-	CurrentRound uint64 `json:"current-round,omitempty"`
+	CurrentRound uint64 `json:"current-round"`
 
 	// NextToken used for pagination, when making another request provide this token
 	// with the next parameter.

--- a/client/v2/common/models/block.go
+++ b/client/v2/common/models/block.go
@@ -5,25 +5,25 @@ package models
 // data/bookkeeping/block.go : Block
 type Block struct {
 	// GenesisHash (gh) hash to which this block belongs.
-	GenesisHash []byte `json:"genesis-hash,omitempty"`
+	GenesisHash []byte `json:"genesis-hash"`
 
 	// GenesisId (gen) ID to which this block belongs.
-	GenesisId string `json:"genesis-id,omitempty"`
+	GenesisId string `json:"genesis-id"`
 
 	// PreviousBlockHash (prev) Previous block hash.
-	PreviousBlockHash []byte `json:"previous-block-hash,omitempty"`
+	PreviousBlockHash []byte `json:"previous-block-hash"`
 
 	// Rewards fields relating to rewards,
 	Rewards BlockRewards `json:"rewards,omitempty"`
 
 	// Round (rnd) Current round on which this block was appended to the chain.
-	Round uint64 `json:"round,omitempty"`
+	Round uint64 `json:"round"`
 
 	// Seed (seed) Sortition seed.
-	Seed []byte `json:"seed,omitempty"`
+	Seed []byte `json:"seed"`
 
 	// Timestamp (ts) Block creation timestamp in seconds since eposh
-	Timestamp uint64 `json:"timestamp,omitempty"`
+	Timestamp uint64 `json:"timestamp"`
 
 	// Transactions (txns) list of transactions corresponding to a given round.
 	Transactions []Transaction `json:"transactions,omitempty"`
@@ -35,7 +35,7 @@ type Block struct {
 	// transactions, only the transactions themselves. Two blocks with the same
 	// transactions but in a different order and with different signatures will have
 	// the same TxnRoot.
-	TransactionsRoot []byte `json:"transactions-root,omitempty"`
+	TransactionsRoot []byte `json:"transactions-root"`
 
 	// TxnCounter (tc) TxnCounter counts the number of transactions committed in the
 	// ledger, from the time at which support for this feature was introduced.

--- a/client/v2/common/models/block_response.go
+++ b/client/v2/common/models/block_response.go
@@ -5,7 +5,7 @@ import "github.com/algorand/go-algorand-sdk/types"
 // BlockResponse encoded block object.
 type BlockResponse struct {
 	// Block block header data.
-	Block types.Block `json:"block,omitempty"`
+	Block types.Block `json:"block"`
 
 	// Cert optional certificate object. This is only included when the format is set
 	// to message pack.

--- a/client/v2/common/models/block_rewards.go
+++ b/client/v2/common/models/block_rewards.go
@@ -4,25 +4,25 @@ package models
 type BlockRewards struct {
 	// FeeSink (fees) accepts transaction fees, it can only spend to the incentive
 	// pool.
-	FeeSink string `json:"fee-sink,omitempty"`
+	FeeSink string `json:"fee-sink"`
 
 	// RewardsCalculationRound (rwcalr) number of leftover MicroAlgos after the
 	// distribution of rewards-rate MicroAlgos for every reward unit in the next round.
-	RewardsCalculationRound uint64 `json:"rewards-calculation-round,omitempty"`
+	RewardsCalculationRound uint64 `json:"rewards-calculation-round"`
 
 	// RewardsLevel (earn) How many rewards, in MicroAlgos, have been distributed to
 	// each RewardUnit of MicroAlgos since genesis.
-	RewardsLevel uint64 `json:"rewards-level,omitempty"`
+	RewardsLevel uint64 `json:"rewards-level"`
 
 	// RewardsPool (rwd) accepts periodic injections from the fee-sink and continually
 	// redistributes them as rewards.
-	RewardsPool string `json:"rewards-pool,omitempty"`
+	RewardsPool string `json:"rewards-pool"`
 
 	// RewardsRate (rate) Number of new MicroAlgos added to the participation stake
 	// from rewards at the next round.
-	RewardsRate uint64 `json:"rewards-rate,omitempty"`
+	RewardsRate uint64 `json:"rewards-rate"`
 
 	// RewardsResidue (frac) Number of leftover MicroAlgos after the distribution of
 	// RewardsRate/rewardUnits MicroAlgos for every reward unit in the next round.
-	RewardsResidue uint64 `json:"rewards-residue,omitempty"`
+	RewardsResidue uint64 `json:"rewards-residue"`
 }

--- a/client/v2/common/models/block_upgrade_state.go
+++ b/client/v2/common/models/block_upgrade_state.go
@@ -3,7 +3,7 @@ package models
 // BlockUpgradeState fields relating to a protocol upgrade.
 type BlockUpgradeState struct {
 	// CurrentProtocol (proto) The current protocol version.
-	CurrentProtocol string `json:"current-protocol,omitempty"`
+	CurrentProtocol string `json:"current-protocol"`
 
 	// NextProtocol (nextproto) The next proposed protocol version.
 	NextProtocol string `json:"next-protocol,omitempty"`

--- a/client/v2/common/models/build_version.go
+++ b/client/v2/common/models/build_version.go
@@ -3,20 +3,20 @@ package models
 // BuildVersion defines a model for BuildVersion.
 type BuildVersion struct {
 	// Branch
-	Branch string `json:"branch,omitempty"`
+	Branch string `json:"branch"`
 
 	// BuildNumber
-	BuildNumber uint64 `json:"build_number,omitempty"`
+	BuildNumber uint64 `json:"build_number"`
 
 	// Channel
-	Channel string `json:"channel,omitempty"`
+	Channel string `json:"channel"`
 
 	// CommitHash
-	CommitHash string `json:"commit_hash,omitempty"`
+	CommitHash string `json:"commit_hash"`
 
 	// Major
-	Major uint64 `json:"major,omitempty"`
+	Major uint64 `json:"major"`
 
 	// Minor
-	Minor uint64 `json:"minor,omitempty"`
+	Minor uint64 `json:"minor"`
 }

--- a/client/v2/common/models/catchpoint_abort_response.go
+++ b/client/v2/common/models/catchpoint_abort_response.go
@@ -3,5 +3,5 @@ package models
 // CatchpointAbortResponse
 type CatchpointAbortResponse struct {
 	// CatchupMessage catchup abort response string
-	CatchupMessage string `json:"catchup-message,omitempty"`
+	CatchupMessage string `json:"catchup-message"`
 }

--- a/client/v2/common/models/catchpoint_start_response.go
+++ b/client/v2/common/models/catchpoint_start_response.go
@@ -3,5 +3,5 @@ package models
 // CatchpointStartResponse
 type CatchpointStartResponse struct {
 	// CatchupMessage catchup start response string
-	CatchupMessage string `json:"catchup-message,omitempty"`
+	CatchupMessage string `json:"catchup-message"`
 }

--- a/client/v2/common/models/compile_response.go
+++ b/client/v2/common/models/compile_response.go
@@ -3,8 +3,8 @@ package models
 // CompileResponse teal compile Result
 type CompileResponse struct {
 	// Hash base32 SHA512_256 of program bytes (Address style)
-	Hash string `json:"hash,omitempty"`
+	Hash string `json:"hash"`
 
 	// Result base64 encoded program bytes
-	Result string `json:"result,omitempty"`
+	Result string `json:"result"`
 }

--- a/client/v2/common/models/dryrun_request.go
+++ b/client/v2/common/models/dryrun_request.go
@@ -7,27 +7,27 @@ import "github.com/algorand/go-algorand-sdk/types"
 // information.
 type DryrunRequest struct {
 	// Accounts
-	Accounts []Account `json:"accounts,omitempty"`
+	Accounts []Account `json:"accounts"`
 
 	// Apps
-	Apps []Application `json:"apps,omitempty"`
+	Apps []Application `json:"apps"`
 
 	// LatestTimestamp latestTimestamp is available to some TEAL scripts. Defaults to
 	// the latest confirmed timestamp this algod is attached to.
-	LatestTimestamp uint64 `json:"latest-timestamp,omitempty"`
+	LatestTimestamp uint64 `json:"latest-timestamp"`
 
 	// ProtocolVersion protocolVersion specifies a specific version string to operate
 	// under, otherwise whatever the current protocol of the network this algod is
 	// running in.
-	ProtocolVersion string `json:"protocol-version,omitempty"`
+	ProtocolVersion string `json:"protocol-version"`
 
 	// Round round is available to some TEAL scripts. Defaults to the current round on
 	// the network this algod is attached to.
-	Round uint64 `json:"round,omitempty"`
+	Round uint64 `json:"round"`
 
 	// Sources
-	Sources []DryrunSource `json:"sources,omitempty"`
+	Sources []DryrunSource `json:"sources"`
 
 	// Txns
-	Txns []types.SignedTxn `json:"txns,omitempty"`
+	Txns []types.SignedTxn `json:"txns"`
 }

--- a/client/v2/common/models/dryrun_response.go
+++ b/client/v2/common/models/dryrun_response.go
@@ -3,12 +3,12 @@ package models
 // DryrunResponse dryrunResponse contains per-txn debug information from a dryrun.
 type DryrunResponse struct {
 	// Error
-	Error string `json:"error,omitempty"`
+	Error string `json:"error"`
 
 	// ProtocolVersion protocol version is the protocol version Dryrun was operated
 	// under.
-	ProtocolVersion string `json:"protocol-version,omitempty"`
+	ProtocolVersion string `json:"protocol-version"`
 
 	// Txns
-	Txns []DryrunTxnResult `json:"txns,omitempty"`
+	Txns []DryrunTxnResult `json:"txns"`
 }

--- a/client/v2/common/models/dryrun_source.go
+++ b/client/v2/common/models/dryrun_source.go
@@ -4,16 +4,16 @@ package models
 // inserted into transactions or application state.
 type DryrunSource struct {
 	// AppIndex
-	AppIndex uint64 `json:"app-index,omitempty"`
+	AppIndex uint64 `json:"app-index"`
 
 	// FieldName fieldName is what kind of sources this is. If lsig then it goes into
 	// the transactions[this.TxnIndex].LogicSig. If approv or clearp it goes into the
 	// Approval Program or Clear State Program of application[this.AppIndex].
-	FieldName string `json:"field-name,omitempty"`
+	FieldName string `json:"field-name"`
 
 	// Source
-	Source string `json:"source,omitempty"`
+	Source string `json:"source"`
 
 	// TxnIndex
-	TxnIndex uint64 `json:"txn-index,omitempty"`
+	TxnIndex uint64 `json:"txn-index"`
 }

--- a/client/v2/common/models/dryrun_state.go
+++ b/client/v2/common/models/dryrun_state.go
@@ -6,14 +6,14 @@ type DryrunState struct {
 	Error string `json:"error,omitempty"`
 
 	// Line line number
-	Line uint64 `json:"line,omitempty"`
+	Line uint64 `json:"line"`
 
 	// Pc program counter
-	Pc uint64 `json:"pc,omitempty"`
+	Pc uint64 `json:"pc"`
 
 	// Scratch
 	Scratch []TealValue `json:"scratch,omitempty"`
 
 	// Stack
-	Stack []TealValue `json:"stack,omitempty"`
+	Stack []TealValue `json:"stack"`
 }

--- a/client/v2/common/models/dryrun_txn_result.go
+++ b/client/v2/common/models/dryrun_txn_result.go
@@ -10,7 +10,7 @@ type DryrunTxnResult struct {
 	AppCallTrace []DryrunState `json:"app-call-trace,omitempty"`
 
 	// Disassembly disassembled program line by line.
-	Disassembly []string `json:"disassembly,omitempty"`
+	Disassembly []string `json:"disassembly"`
 
 	// GlobalDelta application state delta.
 	GlobalDelta []EvalDeltaKeyValue `json:"global-delta,omitempty"`

--- a/client/v2/common/models/error_response.go
+++ b/client/v2/common/models/error_response.go
@@ -6,5 +6,5 @@ type ErrorResponse struct {
 	Data *map[string]interface{} `json:"data,omitempty"`
 
 	// Message
-	Message string `json:"message,omitempty"`
+	Message string `json:"message"`
 }

--- a/client/v2/common/models/eval_delta.go
+++ b/client/v2/common/models/eval_delta.go
@@ -3,7 +3,7 @@ package models
 // EvalDelta represents a TEAL value delta.
 type EvalDelta struct {
 	// Action (at) delta action.
-	Action uint64 `json:"action,omitempty"`
+	Action uint64 `json:"action"`
 
 	// Bytes (bs) bytes value.
 	Bytes string `json:"bytes,omitempty"`

--- a/client/v2/common/models/eval_delta_key_value.go
+++ b/client/v2/common/models/eval_delta_key_value.go
@@ -3,8 +3,8 @@ package models
 // EvalDeltaKeyValue key-value pairs for StateDelta.
 type EvalDeltaKeyValue struct {
 	// Key
-	Key string `json:"key,omitempty"`
+	Key string `json:"key"`
 
 	// Value represents a TEAL value delta.
-	Value EvalDelta `json:"value,omitempty"`
+	Value EvalDelta `json:"value"`
 }

--- a/client/v2/common/models/health_check.go
+++ b/client/v2/common/models/health_check.go
@@ -6,17 +6,17 @@ type HealthCheck struct {
 	Data *map[string]interface{} `json:"data,omitempty"`
 
 	// DbAvailable
-	DbAvailable bool `json:"db-available,omitempty"`
+	DbAvailable bool `json:"db-available"`
 
 	// Errors
 	Errors []string `json:"errors,omitempty"`
 
 	// IsMigrating
-	IsMigrating bool `json:"is-migrating,omitempty"`
+	IsMigrating bool `json:"is-migrating"`
 
 	// Message
-	Message string `json:"message,omitempty"`
+	Message string `json:"message"`
 
 	// Round
-	Round uint64 `json:"round,omitempty"`
+	Round uint64 `json:"round"`
 }

--- a/client/v2/common/models/mini_asset_holding.go
+++ b/client/v2/common/models/mini_asset_holding.go
@@ -3,16 +3,16 @@ package models
 // MiniAssetHolding a simplified version of AssetHolding
 type MiniAssetHolding struct {
 	// Address
-	Address string `json:"address,omitempty"`
+	Address string `json:"address"`
 
 	// Amount
-	Amount uint64 `json:"amount,omitempty"`
+	Amount uint64 `json:"amount"`
 
 	// Deleted whether or not this asset holding is currently deleted from its account.
 	Deleted bool `json:"deleted,omitempty"`
 
 	// IsFrozen
-	IsFrozen bool `json:"is-frozen,omitempty"`
+	IsFrozen bool `json:"is-frozen"`
 
 	// OptedInAtRound round during which the account opted into the asset.
 	OptedInAtRound uint64 `json:"opted-in-at-round,omitempty"`

--- a/client/v2/common/models/node_status_response.go
+++ b/client/v2/common/models/node_status_response.go
@@ -26,32 +26,32 @@ type NodeStatusResponse struct {
 	CatchpointVerifiedAccounts uint64 `json:"catchpoint-verified-accounts,omitempty"`
 
 	// CatchupTime catchupTime in nanoseconds
-	CatchupTime uint64 `json:"catchup-time,omitempty"`
+	CatchupTime uint64 `json:"catchup-time"`
 
 	// LastCatchpoint the last catchpoint seen by the node
 	LastCatchpoint string `json:"last-catchpoint,omitempty"`
 
 	// LastRound lastRound indicates the last round seen
-	LastRound uint64 `json:"last-round,omitempty"`
+	LastRound uint64 `json:"last-round"`
 
 	// LastVersion lastVersion indicates the last consensus version supported
-	LastVersion string `json:"last-version,omitempty"`
+	LastVersion string `json:"last-version"`
 
 	// NextVersion nextVersion of consensus protocol to use
-	NextVersion string `json:"next-version,omitempty"`
+	NextVersion string `json:"next-version"`
 
 	// NextVersionRound nextVersionRound is the round at which the next consensus
 	// version will apply
-	NextVersionRound uint64 `json:"next-version-round,omitempty"`
+	NextVersionRound uint64 `json:"next-version-round"`
 
 	// NextVersionSupported nextVersionSupported indicates whether the next consensus
 	// version is supported by this node
-	NextVersionSupported bool `json:"next-version-supported,omitempty"`
+	NextVersionSupported bool `json:"next-version-supported"`
 
 	// StoppedAtUnsupportedRound stoppedAtUnsupportedRound indicates that the node does
 	// not support the new rounds and has stopped making progress
-	StoppedAtUnsupportedRound bool `json:"stopped-at-unsupported-round,omitempty"`
+	StoppedAtUnsupportedRound bool `json:"stopped-at-unsupported-round"`
 
 	// TimeSinceLastRound timeSinceLastRound in nanoseconds
-	TimeSinceLastRound uint64 `json:"time-since-last-round,omitempty"`
+	TimeSinceLastRound uint64 `json:"time-since-last-round"`
 }

--- a/client/v2/common/models/pending_transaction_response.go
+++ b/client/v2/common/models/pending_transaction_response.go
@@ -43,7 +43,7 @@ type PendingTransactionResponse struct {
 	// PoolError indicates that the transaction was kicked out of this node's
 	// transaction pool (and specifies why that happened). An empty string indicates
 	// the transaction wasn't kicked out of this node's txpool due to an error.
-	PoolError string `json:"pool-error,omitempty"`
+	PoolError string `json:"pool-error"`
 
 	// ReceiverRewards rewards in microalgos applied to the receiver account.
 	ReceiverRewards uint64 `json:"receiver-rewards,omitempty"`
@@ -52,5 +52,5 @@ type PendingTransactionResponse struct {
 	SenderRewards uint64 `json:"sender-rewards,omitempty"`
 
 	// Transaction the raw signed transaction.
-	Transaction types.SignedTxn `json:"txn,omitempty"`
+	Transaction types.SignedTxn `json:"txn"`
 }

--- a/client/v2/common/models/pending_transactions_response.go
+++ b/client/v2/common/models/pending_transactions_response.go
@@ -8,8 +8,8 @@ import "github.com/algorand/go-algorand-sdk/types"
 // fewer than **total-transactions**.
 type PendingTransactionsResponse struct {
 	// TopTransactions an array of signed transaction objects.
-	TopTransactions []types.SignedTxn `json:"top-transactions,omitempty"`
+	TopTransactions []types.SignedTxn `json:"top-transactions"`
 
 	// TotalTransactions total number of transactions in the pool.
-	TotalTransactions uint64 `json:"total-transactions,omitempty"`
+	TotalTransactions uint64 `json:"total-transactions"`
 }

--- a/client/v2/common/models/post_transactions_response.go
+++ b/client/v2/common/models/post_transactions_response.go
@@ -3,5 +3,5 @@ package models
 // PostTransactionsResponse transaction ID of the submission.
 type PostTransactionsResponse struct {
 	// Txid encoding of the transaction hash.
-	Txid string `json:"txId,omitempty"`
+	Txid string `json:"txId"`
 }

--- a/client/v2/common/models/proof_response.go
+++ b/client/v2/common/models/proof_response.go
@@ -3,11 +3,11 @@ package models
 // ProofResponse proof of transaction in a block.
 type ProofResponse struct {
 	// Idx index of the transaction in the block's payset.
-	Idx uint64 `json:"idx,omitempty"`
+	Idx uint64 `json:"idx"`
 
 	// Proof merkle proof of transaction membership.
-	Proof []byte `json:"proof,omitempty"`
+	Proof []byte `json:"proof"`
 
 	// Stibhash hash of SignedTxnInBlock for verifying proof.
-	Stibhash []byte `json:"stibhash,omitempty"`
+	Stibhash []byte `json:"stibhash"`
 }

--- a/client/v2/common/models/state_schema.go
+++ b/client/v2/common/models/state_schema.go
@@ -7,8 +7,8 @@ package models
 type StateSchema struct {
 	// NumByteSlice maximum number of TEAL byte slices that may be stored in the
 	// key/value store.
-	NumByteSlice uint64 `json:"num-byte-slice,omitempty"`
+	NumByteSlice uint64 `json:"num-byte-slice"`
 
 	// NumUint maximum number of TEAL uints that may be stored in the key/value store.
-	NumUint uint64 `json:"num-uint,omitempty"`
+	NumUint uint64 `json:"num-uint"`
 }

--- a/client/v2/common/models/supply_response.go
+++ b/client/v2/common/models/supply_response.go
@@ -3,11 +3,11 @@ package models
 // SupplyResponse supply represents the current supply of MicroAlgos in the system.
 type SupplyResponse struct {
 	// Current_round round
-	Current_round uint64 `json:"current_round,omitempty"`
+	Current_round uint64 `json:"current_round"`
 
 	// OnlineMoney onlineMoney
-	OnlineMoney uint64 `json:"online-money,omitempty"`
+	OnlineMoney uint64 `json:"online-money"`
 
 	// TotalMoney totalMoney
-	TotalMoney uint64 `json:"total-money,omitempty"`
+	TotalMoney uint64 `json:"total-money"`
 }

--- a/client/v2/common/models/teal_key_value.go
+++ b/client/v2/common/models/teal_key_value.go
@@ -3,8 +3,8 @@ package models
 // TealKeyValue represents a key-value pair in an application store.
 type TealKeyValue struct {
 	// Key
-	Key string `json:"key,omitempty"`
+	Key string `json:"key"`
 
 	// Value represents a TEAL value.
-	Value TealValue `json:"value,omitempty"`
+	Value TealValue `json:"value"`
 }

--- a/client/v2/common/models/teal_value.go
+++ b/client/v2/common/models/teal_value.go
@@ -3,11 +3,11 @@ package models
 // TealValue represents a TEAL value.
 type TealValue struct {
 	// Bytes (tb) bytes value.
-	Bytes string `json:"bytes,omitempty"`
+	Bytes string `json:"bytes"`
 
 	// Type (tt) value type.
-	Type uint64 `json:"type,omitempty"`
+	Type uint64 `json:"type"`
 
 	// Uint (ui) uint value.
-	Uint uint64 `json:"uint,omitempty"`
+	Uint uint64 `json:"uint"`
 }

--- a/client/v2/common/models/transaction.go
+++ b/client/v2/common/models/transaction.go
@@ -29,9 +29,9 @@ type Transaction struct {
 	// data/transactions/asset.go : AssetTransferTxnFields
 	AssetTransferTransaction TransactionAssetTransfer `json:"asset-transfer-transaction,omitempty"`
 
-	// AuthAddr (sgnr) The address used to sign the transaction. This is used for
-	// rekeyed accounts to indicate that the sender address did not sign the
-	// transaction.
+	// AuthAddr (sgnr) this is included with signed transactions when the signing
+	// address does not equal the sender. The backend can use this to ensure that auth
+	// addr is equal to the accounts auth addr.
 	AuthAddr string `json:"auth-addr,omitempty"`
 
 	// CloseRewards (rc) rewards applied to close-remainder-to account.
@@ -52,10 +52,10 @@ type Transaction struct {
 	CreatedAssetIndex uint64 `json:"created-asset-index,omitempty"`
 
 	// Fee (fee) Transaction fee.
-	Fee uint64 `json:"fee,omitempty"`
+	Fee uint64 `json:"fee"`
 
 	// FirstValid (fv) First valid round for this transaction.
-	FirstValid uint64 `json:"first-valid,omitempty"`
+	FirstValid uint64 `json:"first-valid"`
 
 	// GenesisHash (gh) Hash of genesis block.
 	GenesisHash []byte `json:"genesis-hash,omitempty"`
@@ -73,7 +73,7 @@ type Transaction struct {
 	Group []byte `json:"group,omitempty"`
 
 	// Id transaction ID
-	Id string `json:"id,omitempty"`
+	Id string `json:"id"`
 
 	// IntraRoundOffset offset into the round where this transaction was confirmed.
 	IntraRoundOffset uint64 `json:"intra-round-offset,omitempty"`
@@ -84,7 +84,7 @@ type Transaction struct {
 	KeyregTransaction TransactionKeyreg `json:"keyreg-transaction,omitempty"`
 
 	// LastValid (lv) Last valid round for this transaction.
-	LastValid uint64 `json:"last-valid,omitempty"`
+	LastValid uint64 `json:"last-valid"`
 
 	// Lease (lx) Base64 encoded 32-byte array. Lease enforces mutual exclusion of
 	// transactions. If this field is nonzero, then once the transaction is confirmed,
@@ -117,14 +117,14 @@ type Transaction struct {
 	RoundTime uint64 `json:"round-time,omitempty"`
 
 	// Sender (snd) Sender's address.
-	Sender string `json:"sender,omitempty"`
+	Sender string `json:"sender"`
 
 	// SenderRewards (rs) rewards applied to sender account.
 	SenderRewards uint64 `json:"sender-rewards,omitempty"`
 
 	// Signature validation signature associated with some data. Only one of the
 	// signatures should be provided.
-	Signature TransactionSignature `json:"signature,omitempty"`
+	Signature TransactionSignature `json:"signature"`
 
 	// Type (type) Indicates what type of transaction this is. Different types have
 	// different fields.

--- a/client/v2/common/models/transaction_application.go
+++ b/client/v2/common/models/transaction_application.go
@@ -14,7 +14,7 @@ type TransactionApplication struct {
 
 	// ApplicationId (apid) ID of the application being configured or empty if
 	// creating.
-	ApplicationId uint64 `json:"application-id,omitempty"`
+	ApplicationId uint64 `json:"application-id"`
 
 	// ApprovalProgram (apap) Logic executed for every application transaction, except
 	// when on-completion is set to "clear". It can read and write global state for the
@@ -27,6 +27,10 @@ type TransactionApplication struct {
 	// application, as well as account-specific local state. Clear state programs
 	// cannot reject the transaction.
 	ClearStateProgram []byte `json:"clear-state-program,omitempty"`
+
+	// ExtraProgramPages (epp) specifies the additional app program len requested in
+	// pages.
+	ExtraProgramPages uint64 `json:"extra-program-pages,omitempty"`
 
 	// ForeignApps (apfa) Lists the applications in addition to the application-id
 	// whose global states may be accessed by this application's approval-program and
@@ -60,7 +64,4 @@ type TransactionApplication struct {
 	// * update
 	// * delete
 	OnCompletion string `json:"on-completion,omitempty"`
-
-	// ExtraPages (extrapages) extra length requested for executing larger application programs
-	ExtraProgramPages int `json:"extra-program-pages,omitempty"`
 }

--- a/client/v2/common/models/transaction_asset_freeze.go
+++ b/client/v2/common/models/transaction_asset_freeze.go
@@ -5,11 +5,11 @@ package models
 // data/transactions/asset.go : AssetFreezeTxnFields
 type TransactionAssetFreeze struct {
 	// Address (fadd) Address of the account whose asset is being frozen or thawed.
-	Address string `json:"address,omitempty"`
+	Address string `json:"address"`
 
 	// AssetId (faid) ID of the asset being frozen or thawed.
-	AssetId uint64 `json:"asset-id,omitempty"`
+	AssetId uint64 `json:"asset-id"`
 
 	// NewFreezeStatus (afrz) The new freeze status.
-	NewFreezeStatus bool `json:"new-freeze-status,omitempty"`
+	NewFreezeStatus bool `json:"new-freeze-status"`
 }

--- a/client/v2/common/models/transaction_asset_transfer.go
+++ b/client/v2/common/models/transaction_asset_transfer.go
@@ -6,10 +6,10 @@ package models
 type TransactionAssetTransfer struct {
 	// Amount (aamt) Amount of asset to transfer. A zero amount transferred to self
 	// allocates that asset in the account's Assets map.
-	Amount uint64 `json:"amount,omitempty"`
+	Amount uint64 `json:"amount"`
 
 	// AssetId (xaid) ID of the asset being transferred.
-	AssetId uint64 `json:"asset-id,omitempty"`
+	AssetId uint64 `json:"asset-id"`
 
 	// CloseAmount number of assets transfered to the close-to account as part of the
 	// transaction.
@@ -22,7 +22,7 @@ type TransactionAssetTransfer struct {
 	CloseTo string `json:"close-to,omitempty"`
 
 	// Receiver (arcv) Recipient address of the transfer.
-	Receiver string `json:"receiver,omitempty"`
+	Receiver string `json:"receiver"`
 
 	// Sender (asnd) The effective sender during a clawback transactions. If this is
 	// not a zero value, the real transaction sender must be the Clawback address from

--- a/client/v2/common/models/transaction_parameters_response.go
+++ b/client/v2/common/models/transaction_parameters_response.go
@@ -5,24 +5,24 @@ package models
 type TransactionParametersResponse struct {
 	// ConsensusVersion consensusVersion indicates the consensus protocol version
 	// as of LastRound.
-	ConsensusVersion string `json:"consensus-version,omitempty"`
+	ConsensusVersion string `json:"consensus-version"`
 
 	// Fee fee is the suggested transaction fee
 	// Fee is in units of micro-Algos per byte.
-	// Fee may fall to zero but a group of N atomic transactions must
-	// still have a fee of at least N*MinTxnFee for the current network protocol.
-	Fee uint64 `json:"fee,omitempty"`
+	// Fee may fall to zero but transactions must still have a fee of
+	// at least MinTxnFee for the current network protocol.
+	Fee uint64 `json:"fee"`
 
 	// GenesisHash genesisHash is the hash of the genesis block.
-	GenesisHash []byte `json:"genesis-hash,omitempty"`
+	GenesisHash []byte `json:"genesis-hash"`
 
 	// GenesisId genesisID is an ID listed in the genesis block.
-	GenesisId string `json:"genesis-id,omitempty"`
+	GenesisId string `json:"genesis-id"`
 
 	// LastRound lastRound indicates the last round seen
-	LastRound uint64 `json:"last-round,omitempty"`
+	LastRound uint64 `json:"last-round"`
 
 	// MinFee the minimum transaction fee (not per byte) required for the
 	// txn to validate for the current network protocol.
-	MinFee uint64 `json:"min-fee,omitempty"`
+	MinFee uint64 `json:"min-fee"`
 }

--- a/client/v2/common/models/transaction_payment.go
+++ b/client/v2/common/models/transaction_payment.go
@@ -5,7 +5,7 @@ package models
 // data/transactions/payment.go : PaymentTxnFields
 type TransactionPayment struct {
 	// Amount (amt) number of MicroAlgos intended to be transferred.
-	Amount uint64 `json:"amount,omitempty"`
+	Amount uint64 `json:"amount"`
 
 	// CloseAmount number of MicroAlgos that were sent to the close-remainder-to
 	// address when closing the sender account.
@@ -16,5 +16,5 @@ type TransactionPayment struct {
 	CloseRemainderTo string `json:"close-remainder-to,omitempty"`
 
 	// Receiver (rcv) receiver's address.
-	Receiver string `json:"receiver,omitempty"`
+	Receiver string `json:"receiver"`
 }

--- a/client/v2/common/models/transaction_response.go
+++ b/client/v2/common/models/transaction_response.go
@@ -3,12 +3,12 @@ package models
 // TransactionResponse
 type TransactionResponse struct {
 	// CurrentRound round at which the results were computed.
-	CurrentRound uint64 `json:"current-round,omitempty"`
+	CurrentRound uint64 `json:"current-round"`
 
 	// Transaction contains all fields common to all transactions and serves as an
 	// envelope to all transactions type.
 	// Definition:
 	// data/transactions/signedtxn.go : SignedTxn
 	// data/transactions/transaction.go : Transaction
-	Transaction Transaction `json:"transaction,omitempty"`
+	Transaction Transaction `json:"transaction"`
 }

--- a/client/v2/common/models/transaction_signature_logicsig.go
+++ b/client/v2/common/models/transaction_signature_logicsig.go
@@ -9,7 +9,7 @@ type TransactionSignatureLogicsig struct {
 
 	// Logic (l) Program signed by a signature or multi signature, or hashed to be the
 	// address of ana ccount. Base64 encoded TEAL program.
-	Logic []byte `json:"logic,omitempty"`
+	Logic []byte `json:"logic"`
 
 	// MultisigSignature (msig) structure holding multiple subsignatures.
 	// Definition:

--- a/client/v2/common/models/transactions_response.go
+++ b/client/v2/common/models/transactions_response.go
@@ -3,12 +3,12 @@ package models
 // TransactionsResponse
 type TransactionsResponse struct {
 	// CurrentRound round at which the results were computed.
-	CurrentRound uint64 `json:"current-round,omitempty"`
+	CurrentRound uint64 `json:"current-round"`
 
 	// NextToken used for pagination, when making another request provide this token
 	// with the next parameter.
 	NextToken string `json:"next-token,omitempty"`
 
 	// Transactions
-	Transactions []Transaction `json:"transactions,omitempty"`
+	Transactions []Transaction `json:"transactions"`
 }

--- a/client/v2/common/models/version.go
+++ b/client/v2/common/models/version.go
@@ -3,14 +3,14 @@ package models
 // Version algod version information.
 type Version struct {
 	// Build
-	Build BuildVersion `json:"build,omitempty"`
+	Build BuildVersion `json:"build"`
 
 	// GenesisHash
-	GenesisHash []byte `json:"genesis_hash_b64,omitempty"`
+	GenesisHash []byte `json:"genesis_hash_b64"`
 
 	// GenesisID
-	GenesisID string `json:"genesis_id,omitempty"`
+	GenesisID string `json:"genesis_id"`
 
 	// Versions
-	Versions []string `json:"versions,omitempty"`
+	Versions []string `json:"versions"`
 }

--- a/client/v2/indexer/indexer.go
+++ b/client/v2/indexer/indexer.go
@@ -39,6 +39,8 @@ func MakeClient(address string, apiToken string) (c *Client, err error) {
 	return
 }
 
+// MakeClientWithHeaders is the factory for constructing a ClientV2 for a
+// given endpoint with custom headers.
 func MakeClientWithHeaders(address string, apiToken string, headers []*common.Header) (c *Client, err error) {
 	commonClientWithHeaders, err := common.MakeClientWithHeaders(address, authHeader, apiToken, headers)
 	c = (*Client)(commonClientWithHeaders)


### PR DESCRIPTION
This PR regenerates the models and clients in this SDK based on new spec changes and improvements from the [generator](https://github.com/algorand/generator) repo.

Specifically, this change adds support for the new extra page fields for algod (https://github.com/algorand/go-algorand/pull/2294) and indexer (https://github.com/algorand/indexer/pull/545).

Note that many fields no longer have the `omitempty` annotation due to improvements in the generator repo.