### PR TITLE
Updates  FromBase64String() to correctly return the signed transaction

### DIFF
--- a/types/basics.go
+++ b/types/basics.go
@@ -67,19 +67,19 @@ func ToMicroAlgos(algos float64) MicroAlgos {
 	return MicroAlgos(math.Round(algos * microAlgoConversionFactor))
 }
 
-func (signedTxn SignedTxn) FromBase64String(b64string string) (SignedTxn, error) {
+func (signedTxn *SignedTxn) FromBase64String(b64string string) error {
 	txnBytes, err := base64.StdEncoding.DecodeString(b64string)
 	if err != nil {
-		return SignedTxn{}, err
+		return err
 	}
 	err = msgpack.Decode(txnBytes, &signedTxn)
 	if err != nil {
-		return SignedTxn{}, err
+		return err
 	}
-	return signedTxn, nil
+	return nil
 }
 
-func (block Block) FromBase64String(b64string string) error {
+func (block *Block) FromBase64String(b64string string) error {
 	txnBytes, err := base64.StdEncoding.DecodeString(b64string)
 	if err != nil {
 		return err

--- a/types/basics.go
+++ b/types/basics.go
@@ -67,16 +67,16 @@ func ToMicroAlgos(algos float64) MicroAlgos {
 	return MicroAlgos(math.Round(algos * microAlgoConversionFactor))
 }
 
-func (signedTxn SignedTxn) FromBase64String(b64string string) error {
+func (signedTxn SignedTxn) FromBase64String(b64string string) (SignedTxn, error) {
 	txnBytes, err := base64.StdEncoding.DecodeString(b64string)
 	if err != nil {
-		return err
+		return SignedTxn{}, err
 	}
 	err = msgpack.Decode(txnBytes, &signedTxn)
 	if err != nil {
-		return err
+		return SignedTxn{}, err
 	}
-	return nil
+	return signedTxn, nil
 }
 
 func (block Block) FromBase64String(b64string string) error {

--- a/types/basics_test.go
+++ b/types/basics_test.go
@@ -12,14 +12,14 @@ import (
 func TestSignedTxnFromBase64String(t *testing.T) {
 	note := []byte("Testing SignedTxnFromBase64String()")
 
-	// Create a signed transaction with a note and base64 encode it
+	// Create a signed transaction with a note and base64 encode it.
 	var st SignedTxn
 	st.Txn.Note = note
-	x := base64.StdEncoding.EncodeToString([]byte(string(msgpack.Encode(st))))
+	b64data := base64.StdEncoding.EncodeToString([]byte(string(msgpack.Encode(st))))
 
-	// Verify that FromBase64String() decodes the txn
+	// Verify that FromBase64String() decodes the txn.
 	var vst SignedTxn
-	err := vst.FromBase64String(x)
+	err := vst.FromBase64String(b64data)
 	require.NoError(t, err)
 	require.Equal(t, vst.Txn.Note, note)
 }
@@ -27,14 +27,14 @@ func TestSignedTxnFromBase64String(t *testing.T) {
 func TestBlockFromBase64String(t *testing.T) {
 	protocol := "Testing BlockFromBase64String()"
 
-	// Create a signed transaction with a note and base64 encode it
+	// Create a block with a protocol string and base64 encode it.
 	var bl Block
 	bl.CurrentProtocol = protocol
-	x := base64.StdEncoding.EncodeToString([]byte(string(msgpack.Encode(bl))))
+	b64data := base64.StdEncoding.EncodeToString([]byte(string(msgpack.Encode(bl))))
 
-	// Verify that FromBase64String() decodes the txn
+	// Verify that FromBase64String() decodes the txn.
 	var vbl Block
-	err := vbl.FromBase64String(x)
+	err := vbl.FromBase64String(b64data)
 	require.NoError(t, err)
 	require.Equal(t, vbl.CurrentProtocol, protocol)
 }

--- a/types/basics_test.go
+++ b/types/basics_test.go
@@ -1,0 +1,40 @@
+package types
+
+import (
+	"testing"
+
+	"encoding/base64"
+	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignedTxnFromBase64String(t *testing.T) {
+	note := []byte("Testing SignedTxnFromBase64String()")
+
+	// Create a signed transaction with a note and base64 encode it
+	var st SignedTxn
+	st.Txn.Note = note
+	x := base64.StdEncoding.EncodeToString([]byte(string(msgpack.Encode(st))))
+
+	// Verify that FromBase64String() decodes the txn
+	var vst SignedTxn
+	err := vst.FromBase64String(x)
+	require.NoError(t, err)
+	require.Equal(t, vst.Txn.Note, note)
+}
+
+func TestBlockFromBase64String(t *testing.T) {
+	protocol := "Testing BlockFromBase64String()"
+
+	// Create a signed transaction with a note and base64 encode it
+	var bl Block
+	bl.CurrentProtocol = protocol
+	x := base64.StdEncoding.EncodeToString([]byte(string(msgpack.Encode(bl))))
+
+	// Verify that FromBase64String() decodes the txn
+	var vbl Block
+	err := vbl.FromBase64String(x)
+	require.NoError(t, err)
+	require.Equal(t, vbl.CurrentProtocol, protocol)
+}


### PR DESCRIPTION
Fix for https://github.com/algorand/go-algorand-sdk/issues/224