### PR TITLE
Fix - v2.0.0 cannot be used with `go mod` 

### DIFF
--- a/future/transaction.go
+++ b/future/transaction.go
@@ -534,7 +534,7 @@ func MakeApplicationCreateTx(
 	note []byte,
 	group types.Digest,
 	lease [32]byte,
-	rekeyTo types.Address, extraPages ...uint32) (tx types.Transaction, err error) {
+	rekeyTo types.Address) (tx types.Transaction, err error) {
 
 	oncomp := types.NoOpOC
 	if optIn {
@@ -558,7 +558,53 @@ func MakeApplicationCreateTx(
 		group,
 		lease,
 		rekeyTo,
-		extraPages...)
+	)
+}
+
+func MakeApplicationCreateTxWithExtraPages(
+	optIn bool,
+	approvalProg []byte,
+	clearProg []byte,
+	globalSchema types.StateSchema,
+	localSchema types.StateSchema,
+	appArgs [][]byte,
+	accounts []string,
+	foreignApps []uint64,
+	foreignAssets []uint64,
+	sp types.SuggestedParams,
+	sender types.Address,
+	note []byte,
+	group types.Digest,
+	lease [32]byte,
+	rekeyTo types.Address, extraPages uint32) (tx types.Transaction, err error) {
+
+	oncomp := types.NoOpOC
+	if optIn {
+		oncomp = types.OptInOC
+	}
+
+	appCallTx, err := MakeApplicationCallTx(
+		0,
+		appArgs,
+		accounts,
+		foreignApps,
+		foreignAssets,
+		oncomp,
+		approvalProg,
+		clearProg,
+		globalSchema,
+		localSchema,
+		sp,
+		sender,
+		note,
+		group,
+		lease,
+		rekeyTo)
+
+	if err != nil {
+		return
+	}
+	return MakeApplicationCallTxWithExtraPages(appCallTx, extraPages)
 }
 
 // MakeApplicationUpdateTx makes a transaction for updating an application's programs (see above for args desc.)
@@ -592,7 +638,7 @@ func MakeApplicationUpdateTx(
 		group,
 		lease,
 		rekeyTo,
-		0)
+	)
 }
 
 // MakeApplicationDeleteTx makes a transaction for deleting an application (see above for args desc.)
@@ -624,7 +670,7 @@ func MakeApplicationDeleteTx(
 		group,
 		lease,
 		rekeyTo,
-		0)
+	)
 }
 
 // MakeApplicationOptInTx makes a transaction for opting in to (allocating
@@ -657,7 +703,7 @@ func MakeApplicationOptInTx(
 		group,
 		lease,
 		rekeyTo,
-		0)
+	)
 }
 
 // MakeApplicationCloseOutTx makes a transaction for closing out of
@@ -690,7 +736,7 @@ func MakeApplicationCloseOutTx(
 		group,
 		lease,
 		rekeyTo,
-		0)
+	)
 }
 
 // MakeApplicationClearStateTx makes a transaction for clearing out all
@@ -724,7 +770,7 @@ func MakeApplicationClearStateTx(
 		group,
 		lease,
 		rekeyTo,
-		0)
+	)
 }
 
 // MakeApplicationNoOpTx makes a transaction for interacting with an existing
@@ -759,7 +805,7 @@ func MakeApplicationNoOpTx(
 		group,
 		lease,
 		rekeyTo,
-		0)
+	)
 }
 
 // MakeApplicationCallTx is a helper for the above ApplicationCall
@@ -781,7 +827,7 @@ func MakeApplicationCallTx(
 	note []byte,
 	group types.Digest,
 	lease [32]byte,
-	rekeyTo types.Address, extraPagesParam ...uint32) (tx types.Transaction, err error) {
+	rekeyTo types.Address) (tx types.Transaction, err error) {
 	tx.Type = types.ApplicationCallTx
 	tx.ApplicationID = types.AppIndex(appIdx)
 	tx.OnCompletion = onCompletion
@@ -792,19 +838,12 @@ func MakeApplicationCallTx(
 		return tx, err
 	}
 
-	var extraPages uint32
-	// take only 1 extraPage value
-	if extraPagesParam != nil {
-		extraPages = extraPagesParam[0]
-	}
-
 	tx.ForeignApps = parseTxnForeignApps(foreignApps)
 	tx.ForeignAssets = parseTxnForeignAssets(foreignAssets)
 	tx.ApprovalProgram = approvalProg
 	tx.ClearStateProgram = clearProg
 	tx.LocalStateSchema = localSchema
 	tx.GlobalStateSchema = globalSchema
-	tx.ExtraProgramPages = extraPages
 
 	var gh types.Digest
 	copy(gh[:], sp.GenesisHash)
@@ -824,6 +863,12 @@ func MakeApplicationCallTx(
 
 	// Update fee
 	return setFee(tx, sp)
+}
+
+func MakeApplicationCallTxWithExtraPages(
+	txn types.Transaction, extraPages uint32) (types.Transaction, error) {
+	txn.ExtraProgramPages = extraPages
+	return txn, nil
 }
 
 func parseTxnAccounts(accounts []string) (parsed []types.Address, err error) {

--- a/future/transaction.go
+++ b/future/transaction.go
@@ -534,7 +534,7 @@ func MakeApplicationCreateTx(
 	note []byte,
 	group types.Digest,
 	lease [32]byte,
-	rekeyTo types.Address, extraPages uint32) (tx types.Transaction, err error) {
+	rekeyTo types.Address, extraPages ...uint32) (tx types.Transaction, err error) {
 
 	oncomp := types.NoOpOC
 	if optIn {
@@ -558,7 +558,7 @@ func MakeApplicationCreateTx(
 		group,
 		lease,
 		rekeyTo,
-		extraPages)
+		extraPages...)
 }
 
 // MakeApplicationUpdateTx makes a transaction for updating an application's programs (see above for args desc.)
@@ -781,7 +781,7 @@ func MakeApplicationCallTx(
 	note []byte,
 	group types.Digest,
 	lease [32]byte,
-	rekeyTo types.Address, extraPages uint32) (tx types.Transaction, err error) {
+	rekeyTo types.Address, extraPagesParam ...uint32) (tx types.Transaction, err error) {
 	tx.Type = types.ApplicationCallTx
 	tx.ApplicationID = types.AppIndex(appIdx)
 	tx.OnCompletion = onCompletion
@@ -790,6 +790,12 @@ func MakeApplicationCallTx(
 	tx.Accounts, err = parseTxnAccounts(accounts)
 	if err != nil {
 		return tx, err
+	}
+
+	var extraPages uint32
+	// take only 1 extraPage value
+	if extraPagesParam != nil {
+		extraPages = extraPagesParam[0]
 	}
 
 	tx.ForeignApps = parseTxnForeignApps(foreignApps)

--- a/future/transaction_test.go
+++ b/future/transaction_test.go
@@ -630,9 +630,12 @@ func TestMakeApplicationCallTx(t *testing.T) {
 	addr := make([]string, 1)
 	addr[0] = "47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU"
 
-	tx, err := MakeApplicationCallTx(0, args, addr, foreignApps, foreignAssets, types.NoOpOC, program, program, gSchema, lSchema, params, types.Address{}, note, types.Digest{}, [32]byte{}, types.Address{}, 2, 1, 3)
+	tx, err := MakeApplicationCallTx(0, args, addr, foreignApps, foreignAssets, types.NoOpOC, program, program, gSchema, lSchema, params, types.Address{}, note, types.Digest{}, [32]byte{}, types.Address{})
 	require.NoError(t, err)
-	require.EqualValues(t, tx.ExtraProgramPages, 2)
+	require.EqualValues(t, 0, tx.ExtraProgramPages)
+	tx, err = MakeApplicationCallTxWithExtraPages(tx, 2)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, tx.ExtraProgramPages)
 }
 
 func TestComputeGroupID(t *testing.T) {

--- a/future/transaction_test.go
+++ b/future/transaction_test.go
@@ -603,6 +603,38 @@ func TestMakeAssetRevocationTransaction(t *testing.T) {
 	require.EqualValues(t, newStxBytes, byteFromBase64(signedGolden))
 }
 
+func TestMakeApplicationCallTx(t *testing.T) {
+	const fee = 1000
+	const firstRound = 2063137
+	const genesisID = "devnet-v1.0"
+	genesisHash := byteFromBase64("sC3P7e2SdbqKJK0tbiCdK9tdSpbe6XeCGKdoNzmlj0E=")
+
+	params := types.SuggestedParams{
+		Fee:             fee,
+		FirstRoundValid: firstRound,
+		LastRoundValid:  firstRound + 1000,
+		GenesisHash:     genesisHash,
+		GenesisID:       genesisID,
+		FlatFee:         true,
+	}
+	note := byteFromBase64("8xMCTuLQ810=")
+	program := []byte{1, 32, 1, 1, 34}
+	args := make([][]byte, 2)
+	args[0] = []byte("123")
+	args[1] = []byte("456")
+	foreignApps := make([]uint64, 1)
+	foreignApps[0] = 10
+	foreignAssets := foreignApps
+	gSchema := types.StateSchema{NumUint: uint64(1), NumByteSlice: uint64(1)}
+	lSchema := types.StateSchema{NumUint: uint64(1), NumByteSlice: uint64(1)}
+	addr := make([]string, 1)
+	addr[0] = "47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU"
+
+	tx, err := MakeApplicationCallTx(0, args, addr, foreignApps, foreignAssets, types.NoOpOC, program, program, gSchema, lSchema, params, types.Address{}, note, types.Digest{}, [32]byte{}, types.Address{}, 2, 1, 3)
+	require.NoError(t, err)
+	require.EqualValues(t, tx.ExtraProgramPages, 2)
+}
+
 func TestComputeGroupID(t *testing.T) {
 	// compare regular transactions created in SDK with 'goal clerk send' result
 	// compare transaction group created in SDK with 'goal clerk group' result

--- a/test/applications_integration_test.go
+++ b/test/applications_integration_test.go
@@ -148,38 +148,33 @@ func iBuildAnApplicationTransaction(
 	lSchema := types.StateSchema{NumUint: uint64(localInts), NumByteSlice: uint64(localBytes)}
 	switch operation {
 	case "create":
-		tx, err = future.MakeApplicationCreateTx(false, approvalP, clearP,
-			gSchema, lSchema, args, accs, fApp, fAssets,
-			suggestedParams, transientAccount.Address, nil, types.Digest{}, [32]byte{}, types.Address{}, uint32(extraPages))
-		if err != nil {
-			return err
-		}
-
-		// test extrapPages is optional
-		if len(approvalP) <= 2048 && len(clearP) <= 2048 {
+		if extraPages > 0 {
+			tx, err = future.MakeApplicationCreateTxWithExtraPages(false, approvalP, clearP,
+				gSchema, lSchema, args, accs, fApp, fAssets,
+				suggestedParams, transientAccount.Address, nil, types.Digest{}, [32]byte{}, types.Address{}, uint32(extraPages))
+		} else {
 			tx, err = future.MakeApplicationCreateTx(false, approvalP, clearP,
 				gSchema, lSchema, args, accs, fApp, fAssets,
 				suggestedParams, transientAccount.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
-			if err != nil {
-				return err
-			}
 		}
 
-	case "create_optin":
-		tx, err = future.MakeApplicationCreateTx(true, approvalP, clearP,
-			gSchema, lSchema, args, accs, fApp, fAssets,
-			suggestedParams, transientAccount.Address, nil, types.Digest{}, [32]byte{}, types.Address{}, uint32(extraPages))
 		if err != nil {
 			return err
 		}
-		// test extrapPages is optional
-		if len(approvalP) <= 2048 && len(clearP) <= 2048 {
+
+	case "create_optin":
+		if extraPages > 0 {
+			tx, err = future.MakeApplicationCreateTxWithExtraPages(true, approvalP, clearP,
+				gSchema, lSchema, args, accs, fApp, fAssets,
+				suggestedParams, transientAccount.Address, nil, types.Digest{}, [32]byte{}, types.Address{}, uint32(extraPages))
+		} else {
 			tx, err = future.MakeApplicationCreateTx(true, approvalP, clearP,
 				gSchema, lSchema, args, accs, fApp, fAssets,
 				suggestedParams, transientAccount.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
-			if err != nil {
-				return err
-			}
+		}
+
+		if err != nil {
+			return err
 		}
 	case "update":
 		tx, err = future.MakeApplicationUpdateTx(applicationId, args, accs, fApp, fAssets,

--- a/test/applications_integration_test.go
+++ b/test/applications_integration_test.go
@@ -155,6 +155,16 @@ func iBuildAnApplicationTransaction(
 			return err
 		}
 
+		// test extrapPages is optional
+		if len(approvalP) <= 2048 && len(clearP) <= 2048 {
+			tx, err = future.MakeApplicationCreateTx(false, approvalP, clearP,
+				gSchema, lSchema, args, accs, fApp, fAssets,
+				suggestedParams, transientAccount.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
+			if err != nil {
+				return err
+			}
+		}
+
 	case "create_optin":
 		tx, err = future.MakeApplicationCreateTx(true, approvalP, clearP,
 			gSchema, lSchema, args, accs, fApp, fAssets,
@@ -162,7 +172,15 @@ func iBuildAnApplicationTransaction(
 		if err != nil {
 			return err
 		}
-
+		// test extrapPages is optional
+		if len(approvalP) <= 2048 && len(clearP) <= 2048 {
+			tx, err = future.MakeApplicationCreateTx(true, approvalP, clearP,
+				gSchema, lSchema, args, accs, fApp, fAssets,
+				suggestedParams, transientAccount.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
+			if err != nil {
+				return err
+			}
+		}
 	case "update":
 		tx, err = future.MakeApplicationUpdateTx(applicationId, args, accs, fApp, fAssets,
 			approvalP, clearP,
@@ -174,7 +192,7 @@ func iBuildAnApplicationTransaction(
 	case "call":
 		tx, err = future.MakeApplicationCallTx(applicationId, args, accs,
 			fApp, fAssets, types.NoOpOC, approvalP, clearP, gSchema, lSchema,
-			suggestedParams, transientAccount.Address, nil, types.Digest{}, [32]byte{}, types.Address{}, 0)
+			suggestedParams, transientAccount.Address, nil, types.Digest{}, [32]byte{}, types.Address{})
 	case "optin":
 		tx, err = future.MakeApplicationOptInTx(applicationId, args, accs, fApp, fAssets,
 			suggestedParams, transientAccount.Address, nil, types.Digest{}, [32]byte{}, types.Address{})

--- a/test/applications_unit_test.go
+++ b/test/applications_unit_test.go
@@ -107,7 +107,7 @@ func iBuildAnApplicationTransactionUnit(
 	case "call":
 		tx, err = future.MakeApplicationCallTx(applicationId, args, accs,
 			fApp, fAssets, types.NoOpOC, approvalP, clearP, gSchema, lSchema,
-			suggestedParams, addr1, nil, types.Digest{}, [32]byte{}, types.Address{}, 0)
+			suggestedParams, addr1, nil, types.Digest{}, [32]byte{}, types.Address{})
 	case "optin":
 		tx, err = future.MakeApplicationOptInTx(applicationId, args, accs, fApp, fAssets,
 			suggestedParams, addr1, nil, types.Digest{}, [32]byte{}, types.Address{})

--- a/test/applications_unit_test.go
+++ b/test/applications_unit_test.go
@@ -89,9 +89,16 @@ func iBuildAnApplicationTransactionUnit(
 
 	switch operation {
 	case "create":
-		tx, err = future.MakeApplicationCreateTx(false, approvalP, clearP,
-			gSchema, lSchema, args, accs, fApp, fAssets,
-			suggestedParams, addr1, nil, types.Digest{}, [32]byte{}, types.Address{}, uint32(extraPages))
+		if extraPages > 0 {
+			tx, err = future.MakeApplicationCreateTxWithExtraPages(false, approvalP, clearP,
+				gSchema, lSchema, args, accs, fApp, fAssets,
+				suggestedParams, addr1, nil, types.Digest{}, [32]byte{}, types.Address{}, uint32(extraPages))
+		} else {
+			tx, err = future.MakeApplicationCreateTx(false, approvalP, clearP,
+				gSchema, lSchema, args, accs, fApp, fAssets,
+				suggestedParams, addr1, nil, types.Digest{}, [32]byte{}, types.Address{})
+		}
+
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
v2.0.0 cannot be obtained using Go tools,
`go get github.com/algorand/go-algorand-sdk/...@v2.0.0: github.com/algorand/go-algorand-sdk@v2.0.0: invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v2`

 adding extraPages as a new parameter to MakeApplicationCallTx(...) was a breaking change which required upgrading the package to v2.0.0.   This PR fixes this issue. 