### PR TITLE
Use correct go version in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ go:
   - "1.12"
   - "1.13"
   - "1.14"
+  - "1.15"
+  - "1.16"
 install:
   - go get -u golang.org/x/lint/golint
 script:

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.13-stretch
+ARG GO_IMAGE=golang:1.13-stretch
+FROM GO_IMAGE
 
 # Copy SDK code into the container
 RUN mkdir -p $HOME/go-algorand-sdk

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG GO_IMAGE=golang:1.13-stretch
-FROM GO_IMAGE
+FROM $GO_IMAGE
 
 # Copy SDK code into the container
 RUN mkdir -p $HOME/go-algorand-sdk

--- a/test/docker/run_docker.sh
+++ b/test/docker/run_docker.sh
@@ -12,6 +12,8 @@ mv test-harness/features test/features
 GO_VERSION=$(go version | cut -d' ' -f 3 | cut -d'.' -f 1,2)
 GO_IMAGE=golang:${GO_VERSION:2}-stretch
 
+echo "Building docker image from base \"$GO_IMAGE\""
+
 #build test environment
 docker build -t go-sdk-testing --build-arg GO_IMAGE="$GO_IMAGE" -f test/docker/Dockerfile "$(pwd)"
 

--- a/test/docker/run_docker.sh
+++ b/test/docker/run_docker.sh
@@ -9,8 +9,11 @@ git clone --single-branch --branch master https://github.com/algorand/algorand-s
 #copy feature files into project
 mv test-harness/features test/features
 
+GO_VERSION=$(go version | cut -d' ' -f 3 | cut -d'.' -f 1,2)
+GO_IMAGE=golang:${GO_VERSION:2}-stretch
+
 #build test environment
-docker build -t go-sdk-testing -f test/docker/Dockerfile "$(pwd)"
+docker build -t go-sdk-testing --build-arg GO_IMAGE="$GO_IMAGE" -f test/docker/Dockerfile "$(pwd)"
 
 # Start test harness environment
 ./test-harness/scripts/up.sh -p


### PR DESCRIPTION
I noticed that the Dockerfile for this repo always uses Go 1.13, which means our Travis build matrix for multiple Go versions is not working.

So I made some modifications to pull from a base image with the same version of Go that the system currently uses. I also added Go versions 1.15 and 1.16 to our build matrix.