### PR TITLE
Stop testing Go 1.12, start testing 1.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 dist: bionic
 language: go
 go:
-  - "1.12"
   - "1.13"
   - "1.14"
   - "1.15"
   - "1.16"
+  - "1.17"
 install:
   - go get -u golang.org/x/lint/golint
 script:


### PR DESCRIPTION
Since our go.mod declares it uses Go 1.13, it's no longer necessary to test with Go 1.12. Additionally, since Go 1.17 has been released, we should test it too.