### PR TITLE
Fix wait for confirmation function

### DIFF
--- a/test/applications_integration_test.go
+++ b/test/applications_integration_test.go
@@ -66,7 +66,7 @@ func iCreateANewTransientAccountAndFundItWithMicroalgos(microalgos int) error {
 	if err != nil {
 		return err
 	}
-	_, err = future.WaitForConfirmation(algodV2client, ltxid, 0, context.Background())
+	_, err = future.WaitForConfirmation(algodV2client, ltxid, 5, context.Background())
 	if err != nil {
 		return err
 	}
@@ -218,7 +218,7 @@ func iSignAndSubmitTheTransactionSavingTheTxidIfThereIsAnErrorItIs(err string) e
 }
 
 func iWaitForTheTransactionToBeConfirmed() error {
-	_, err := future.WaitForConfirmation(algodV2client, txid, 0, context.Background())
+	_, err := future.WaitForConfirmation(algodV2client, txid, 5, context.Background())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes the following issues with the wait for confirmation function:
1. `PoolError` was being ignored
2. If the call to `PendingTransactionInformation` returns an error, that error should be ignored and the function should continue retrying if `waitRounds` allows it.
3. Removed the special value 0 for `waitRounds` which allows indefinitely waiting. This is a dangerous feature, since your code might actually wait forever if it never sees the transaction fail. Instead a value of 1000 (the maximum txn life) can be used to imply the same thing, and in reality is the longest you will ever have to wait.