### PR TITLE
Support ABI reference types and other improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,11 @@ test:
 
 unit:
 	go test $(TEST_SOURCES_NO_CUCUMBER)
-	cd test && go test --godog.strict=true --godog.format=pretty --godog.tags="@unit.offline,@unit.algod,@unit.indexer,@unit.rekey,@unit.tealsign,@unit.dryrun,@unit.responses,@unit.applications,@unit.transactions,@unit.indexer.rekey,@unit.responses.messagepack,@unit.responses.231,@unit.responses.messagepack.231,@unit.responses.genesis,@unit.feetest,@unit.indexer.logs,@unit.abijson,@unit.transactions.payment,@unit.atomic_transaction_composer" --test.v .
+	cd test && go test -timeout 0s --godog.strict=true --godog.format=pretty --godog.tags="@unit.offline,@unit.algod,@unit.indexer,@unit.rekey,@unit.tealsign,@unit.dryrun,@unit.responses,@unit.applications,@unit.transactions,@unit.indexer.rekey,@unit.responses.messagepack,@unit.responses.231,@unit.responses.messagepack.231,@unit.responses.genesis,@unit.feetest,@unit.indexer.logs,@unit.abijson,@unit.transactions.payment,@unit.atomic_transaction_composer" --test.v .
 
 integration:
 	go test $(TEST_SOURCES_NO_CUCUMBER)
-	cd test && go test --godog.strict=true --godog.format=pretty --godog.tags="@algod,@assets,@auction,@kmd,@send,@template,@indexer,@rekey,@dryrun,@compile,@applications.verified,@indexer.applications,@indexer.231,@abi" --test.v .
+	cd test && go test -timeout 0s --godog.strict=true --godog.format=pretty --godog.tags="@algod,@assets,@auction,@kmd,@send,@template,@indexer,@rekey,@dryrun,@compile,@applications.verified,@indexer.applications,@indexer.231,@abi" --test.v .
 
 docker-test:
 	./test/docker/run_docker.sh

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -1,0 +1,23 @@
+package abi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoAlgorandImportWorks(t *testing.T) {
+	// This test is not meant to be exhaustive. It's just a simple test to
+	// verify importing the ABI package from go-algorand is working
+
+	abiType, err := TypeOf("uint64")
+	require.NoError(t, err)
+
+	valueToEncode := 10000
+	expected := []byte{0, 0, 0, 0, 0, 0, 39, 16}
+
+	actual, err := abiType.Encode(valueToEncode)
+	require.NoError(t, err)
+
+	require.Equal(t, expected, actual)
+}

--- a/abi/interactions.go
+++ b/abi/interactions.go
@@ -6,11 +6,14 @@ import (
 	"strings"
 
 	"github.com/algorand/go-algorand-sdk/types"
-	"github.com/algorand/go-algorand/data/abi"
 )
 
-var TransactionArgTypes = map[string]interface{}{
-	"txn":                           nil, // denotes a placeholder for any of the size types below
+// AnyTransactionType is the ABI argument type string for a nonspecific
+// transaction argument
+const AnyTransactionType = "txn"
+
+var transactionArgTypes = map[string]interface{}{
+	AnyTransactionType:              nil, // denotes a placeholder for any of the size types below
 	string(types.PaymentTx):         nil,
 	string(types.KeyRegistrationTx): nil,
 	string(types.AssetConfigTx):     nil,
@@ -19,35 +22,133 @@ var TransactionArgTypes = map[string]interface{}{
 	string(types.ApplicationCallTx): nil,
 }
 
+// IsTransactionType checks if a type string represents a transaction type
+// argument, such as "txn", "pay", "keyreg", etc.
+func IsTransactionType(typeStr string) bool {
+	_, ok := transactionArgTypes[typeStr]
+	return ok
+}
+
+// AccountReferenceType is the ABI argument type string for account references
+const AccountReferenceType = "account"
+
+// AssetReferenceType is the ABI argument type string for asset references
+const AssetReferenceType = "asset"
+
+// ApplicationReferenceType is the ABI argument type string for application
+// references
+const ApplicationReferenceType = "application"
+
+var referenceArgTypes = map[string]interface{}{
+	AccountReferenceType:     nil,
+	AssetReferenceType:       nil,
+	ApplicationReferenceType: nil,
+}
+
+// IsReferenceType checks if a type string represents a reference type argument,
+// such as "account", "asset", or "application".
+func IsReferenceType(typeStr string) bool {
+	_, ok := referenceArgTypes[typeStr]
+	return ok
+}
+
+// Arg represents an ABI Method argument
 type Arg struct {
-	Name    string `json:"name,omitempty"`
-	AbiType string `json:"type"`
-	Desc    string `json:"desc,omitempty"`
+	// Optional, user-friendly name for the argument
+	Name string `json:"name,omitempty"`
+	// Optional, user-friendly description for the argument
+	Desc string `json:"desc,omitempty"`
+	// The type of the argument as a string. See the method GetTypeObject to
+	// obtain the ABI type object
+	Type string `json:"type"`
+	// A hidden type object cache that holds the parsed type object
+	typeObject *Type `json:"-"`
 }
 
+// IsTransactionArg checks if this argument's type is a transaction type
+func (a Arg) IsTransactionArg() bool {
+	return IsTransactionType(a.Type)
+}
+
+// IsReferenceArg checks if this argument's type is a reference type
+func (a Arg) IsReferenceArg() bool {
+	return IsReferenceType(a.Type)
+}
+
+// GetTypeObject parses and returns the ABI type object for this argument's
+// type. An error will be returned if this argument's type is a transaction or
+// reference type
+func (a *Arg) GetTypeObject() (Type, error) {
+	if a.IsTransactionArg() {
+		return Type{}, fmt.Errorf("Invalid operation on transaction type %s", a.Type)
+	}
+	if a.IsReferenceArg() {
+		return Type{}, fmt.Errorf("Invalid operation on reference type %s", a.Type)
+	}
+	if a.typeObject != nil {
+		return *a.typeObject, nil
+	}
+	typeObject, err := TypeOf(a.Type)
+	if err == nil {
+		a.typeObject = &typeObject
+	}
+	return typeObject, err
+}
+
+// VoidReturnType is the ABI return type string for a method that does not have
+// a return value
+const VoidReturnType = "void"
+
+// Return represents an ABI method return value
 type Return struct {
-	AbiType string `json:"type"`
-	Desc    string `json:"desc,omitempty"`
+	// Optional, user-friendly description for the return value
+	Desc string `json:"desc,omitempty"`
+	// The type of the return value as a string. See the method GetTypeObject to
+	// obtain the ABI type object
+	Type string `json:"type"`
+	// A hidden type object cache that holds the parsed type object
+	typeObject *Type `json:"-"`
 }
 
+// IsVoid checks if this return type is void, meaning the method does not have
+// any return value
+func (r Return) IsVoid() bool {
+	return r.Type == VoidReturnType
+}
+
+// GetTypeObject parses and returns the ABI type object for this return type.
+// An error will be returned if this is a void return type.
+func (r *Return) GetTypeObject() (Type, error) {
+	if r.IsVoid() {
+		return Type{}, fmt.Errorf("Invalid operation on void return type")
+	}
+	if r.typeObject != nil {
+		return *r.typeObject, nil
+	}
+	typeObject, err := TypeOf(r.Type)
+	if err == nil {
+		r.typeObject = &typeObject
+	}
+	return typeObject, err
+}
+
+// Method represents an individual ABI method definition
 type Method struct {
-	Name    string `json:"name"`
-	Desc    string `json:"desc,omitempty"`
-	Args    []Arg  `json:"args"`
+	// The name of the method
+	Name string `json:"name"`
+	// Optional, user-friendly description for the method
+	Desc string `json:"desc,omitempty"`
+	// The arguments of the method, in order
+	Args []Arg `json:"args"`
+	// Information about the method's return value
 	Returns Return `json:"returns"`
 }
 
-func (method *Method) GetTxCountFromMethod() int {
-	cnt := 1
-	for _, arg := range method.Args {
-		if _, ok := TransactionArgTypes[arg.AbiType]; ok {
-			cnt++
-		}
-	}
-
-	return cnt
-}
-
+// parseMethodArgs parses the arguments from a method signature string.
+// trMethod is the complete method signature and startIdx is the index of the
+// opening parenthesis of the arguments list. This function returns a list of
+// the argument types from the method signature and the index of the closing
+// parenthesis of the arguments list.
 func parseMethodArgs(strMethod string, startIdx int) ([]string, int, error) {
 	// handle no args
 	if startIdx < len(strMethod)-1 && strMethod[startIdx+1] == ')' {
@@ -73,12 +174,6 @@ func parseMethodArgs(strMethod string, startIdx int) ([]string, int, error) {
 
 		if strMethod[curPos] == ',' || parenCnt == 0 {
 			strArg := strMethod[prevPos:curPos]
-			if _, ok := TransactionArgTypes[strArg]; !ok {
-				if _, err := abi.TypeOf(strArg); err != nil {
-					return nil, -1, err
-				}
-			}
-
 			argTypes = append(argTypes, strArg)
 			prevPos = curPos + 1
 		}
@@ -96,6 +191,7 @@ func parseMethodArgs(strMethod string, startIdx int) ([]string, int, error) {
 	return argTypes, closeIdx, nil
 }
 
+// MethodFromSignature decoded a method signature string into a Method object.
 func MethodFromSignature(methodStr string) (Method, error) {
 	openIdx := strings.Index(methodStr, "(")
 	if openIdx == -1 {
@@ -112,9 +208,10 @@ func MethodFromSignature(methodStr string) (Method, error) {
 		return Method{}, err
 	}
 
-	returnType := methodStr[closeIdx+1:]
-	if returnType != "void" {
-		_, err := abi.TypeOf(returnType)
+	returnType := Return{Type: methodStr[closeIdx+1:]}
+	if !returnType.IsVoid() {
+		// fill type object cache and catch any errors
+		_, err := returnType.GetTypeObject()
 		if err != nil {
 			return Method{}, err
 		}
@@ -122,48 +219,88 @@ func MethodFromSignature(methodStr string) (Method, error) {
 
 	args := make([]Arg, len(argTypes))
 	for i, argType := range argTypes {
-		args[i] = Arg{
-			Name:    "",
-			AbiType: argType,
+		args[i].Type = argType
+
+		if IsTransactionType(argType) || IsReferenceType(argType) {
+			continue
+		}
+
+		// fill type object cache and catch any errors
+		_, err := args[i].GetTypeObject()
+		if err != nil {
+			return Method{}, err
 		}
 	}
 
 	return Method{
 		Name:    name,
 		Args:    args,
-		Returns: Return{AbiType: returnType},
+		Returns: returnType,
 	}, nil
 }
 
+// GetSignature calculates and returns the signature of the method
 func (method *Method) GetSignature() string {
 	var methodSignature string
 	methodSignature += method.Name + "("
 
 	var strTypes []string
 	for _, arg := range method.Args {
-		strTypes = append(strTypes, arg.AbiType)
+		strTypes = append(strTypes, arg.Type)
 	}
 
 	methodSignature += strings.Join(strTypes, ",")
 	methodSignature += ")"
-	methodSignature += method.Returns.AbiType
+	methodSignature += method.Returns.Type
 
 	return methodSignature
 }
 
+// GetSelector calculates and returns the 4-byte selector of the method
 func (method *Method) GetSelector() []byte {
 	sig := method.GetSignature()
 	sigHash := sha512.Sum512_256([]byte(sig))
 	return sigHash[:4]
 }
 
+// GetTxCount returns the number of transactions required to invoke this method
+func (method *Method) GetTxCount() int {
+	cnt := 1
+	for _, arg := range method.Args {
+		if arg.IsTransactionArg() {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+// Interface represents an ABI interface, which is a logically grouped
+// collection of methods
 type Interface struct {
-	Name    string   `json:"name"`
+	// A user-friendly name for the interface
+	Name string `json:"name"`
+	// Optional, user-friendly description for the interface
+	Desc string `json:"desc,omitempty"`
+	// The methods that the interface contains
 	Methods []Method `json:"methods"`
 }
 
+// ContractNetworkInfo contains network-specific information about the contract
+type ContractNetworkInfo struct {
+	// The application ID of the contract for this network
+	AppID uint64 `json:"appID"`
+}
+
+// Contract represents an ABI contract, which is a concrete set of methods
+// implemented by a single app
 type Contract struct {
-	Name    string   `json:"name"`
-	AppId   uint64   `json:"appId"`
+	// A user-friendly name for the contract
+	Name string `json:"name"`
+	// Optional, user-friendly description for the contract
+	Desc string `json:"desc,omitempty"`
+	// Optional information about the contract's instances across different
+	// networks
+	Networks map[string]ContractNetworkInfo `json:"networks,omitempty"`
+	// The methods that the contract implements
 	Methods []Method `json:"methods"`
 }

--- a/abi/interactions.go
+++ b/abi/interactions.go
@@ -56,13 +56,13 @@ func IsReferenceType(typeStr string) bool {
 type Arg struct {
 	// Optional, user-friendly name for the argument
 	Name string `json:"name,omitempty"`
-	// Optional, user-friendly description for the argument
-	Desc string `json:"desc,omitempty"`
 	// The type of the argument as a string. See the method GetTypeObject to
 	// obtain the ABI type object
 	Type string `json:"type"`
 	// A hidden type object cache that holds the parsed type object
 	typeObject *Type `json:"-"`
+	// Optional, user-friendly description for the argument
+	Desc string `json:"desc,omitempty"`
 }
 
 // IsTransactionArg checks if this argument's type is a transaction type
@@ -101,13 +101,13 @@ const VoidReturnType = "void"
 
 // Return represents an ABI method return value
 type Return struct {
-	// Optional, user-friendly description for the return value
-	Desc string `json:"desc,omitempty"`
 	// The type of the return value as a string. See the method GetTypeObject to
 	// obtain the ABI type object
 	Type string `json:"type"`
 	// A hidden type object cache that holds the parsed type object
 	typeObject *Type `json:"-"`
+	// Optional, user-friendly description for the return value
+	Desc string `json:"desc,omitempty"`
 }
 
 // IsVoid checks if this return type is void, meaning the method does not have

--- a/abi/interactions_test.go
+++ b/abi/interactions_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestMethodFromSignature(t *testing.T) {
 	expectedArgs := []Arg{
-		{Name: "", AbiType: "uint32", Desc: ""},
-		{Name: "", AbiType: "uint32", Desc: ""},
+		{Name: "", Type: "uint32", Desc: ""},
+		{Name: "", Type: "uint32", Desc: ""},
 	}
 	expected := Method{
 		Name:    "add",
 		Desc:    "",
 		Args:    expectedArgs,
-		Returns: Return{AbiType: "uint32", Desc: ""},
+		Returns: Return{Type: "uint32", Desc: ""},
 	}
 
 	methodSig := "add(uint32,uint32)uint32"
@@ -28,14 +28,14 @@ func TestMethodFromSignature(t *testing.T) {
 
 func TestMethodFromSignatureWithTuple(t *testing.T) {
 	expectedArgs := []Arg{
-		{Name: "", AbiType: "(uint32,(uint32,uint32))", Desc: ""},
-		{Name: "", AbiType: "uint32", Desc: ""},
+		{Name: "", Type: "(uint32,(uint32,uint32))", Desc: ""},
+		{Name: "", Type: "uint32", Desc: ""},
 	}
 	expected := Method{
 		Name:    "add",
 		Desc:    "",
 		Args:    expectedArgs,
-		Returns: Return{AbiType: "(uint32,uint32)", Desc: ""},
+		Returns: Return{Type: "(uint32,uint32)", Desc: ""},
 	}
 
 	methodSig := "add((uint32,(uint32,uint32)),uint32)(uint32,uint32)"
@@ -47,14 +47,14 @@ func TestMethodFromSignatureWithTuple(t *testing.T) {
 
 func TestMethodFromSignatureWithVoidReturn(t *testing.T) {
 	expectedArgs := []Arg{
-		{Name: "", AbiType: "uint32", Desc: ""},
-		{Name: "", AbiType: "uint32", Desc: ""},
+		{Name: "", Type: "uint32", Desc: ""},
+		{Name: "", Type: "uint32", Desc: ""},
 	}
 	expected := Method{
 		Name:    "add",
 		Desc:    "",
 		Args:    expectedArgs,
-		Returns: Return{AbiType: "void", Desc: ""},
+		Returns: Return{Type: "void", Desc: ""},
 	}
 
 	methodSig := "add(uint32,uint32)void"
@@ -70,7 +70,7 @@ func TestMethodFromSignatureWithNoArgs(t *testing.T) {
 		Name:    "add",
 		Desc:    "",
 		Args:    expectedArgs,
-		Returns: Return{AbiType: "void", Desc: ""},
+		Returns: Return{Type: "void", Desc: ""},
 	}
 
 	methodSig := "add()void"
@@ -106,15 +106,15 @@ func TestMethodFromSignatureInvalidAbiType(t *testing.T) {
 
 func TestGetSignature(t *testing.T) {
 	expectedArgs := []Arg{
-		{Name: "", AbiType: "uint32", Desc: ""},
-		{Name: "", AbiType: "uint32", Desc: ""},
+		{Name: "", Type: "uint32", Desc: ""},
+		{Name: "", Type: "uint32", Desc: ""},
 	}
 
 	method := Method{
 		Name:    "add",
 		Desc:    "",
 		Args:    expectedArgs,
-		Returns: Return{AbiType: "uint32", Desc: ""},
+		Returns: Return{Type: "uint32", Desc: ""},
 	}
 
 	expected := "add(uint32,uint32)uint32"
@@ -123,15 +123,15 @@ func TestGetSignature(t *testing.T) {
 
 func TestGetSelector(t *testing.T) {
 	args := []Arg{
-		{Name: "", AbiType: "uint32", Desc: ""},
-		{Name: "", AbiType: "uint32", Desc: ""},
+		{Name: "", Type: "uint32", Desc: ""},
+		{Name: "", Type: "uint32", Desc: ""},
 	}
 
 	method := Method{
 		Name:    "add",
 		Desc:    "",
 		Args:    args,
-		Returns: Return{AbiType: "uint32", Desc: ""},
+		Returns: Return{Type: "uint32", Desc: ""},
 	}
 
 	expected := []byte{0x3e, 0x1e, 0x52, 0xbd}
@@ -140,15 +140,15 @@ func TestGetSelector(t *testing.T) {
 
 func TestEncodeJsonMethod(t *testing.T) {
 	args := []Arg{
-		{Name: "0", AbiType: "uint32", Desc: ""},
-		{Name: "1", AbiType: "uint32", Desc: ""},
+		{Name: "0", Type: "uint32", Desc: ""},
+		{Name: "1", Type: "uint32", Desc: ""},
 	}
 
 	method := Method{
 		Name:    "add",
 		Desc:    "",
 		Args:    args,
-		Returns: Return{AbiType: "uint32", Desc: ""},
+		Returns: Return{Type: "uint32", Desc: ""},
 	}
 
 	expected := `{"name":"add","args":[{"name":"0","type":"uint32"},{"name":"1","type":"uint32"}],"returns":{"type":"uint32"}}`
@@ -160,15 +160,15 @@ func TestEncodeJsonMethod(t *testing.T) {
 
 func TestEncodeJsonMethodWithDescription(t *testing.T) {
 	args := []Arg{
-		{Name: "0", AbiType: "uint32", Desc: "description"},
-		{Name: "1", AbiType: "uint32", Desc: "description"},
+		{Name: "0", Type: "uint32", Desc: "description"},
+		{Name: "1", Type: "uint32", Desc: "description"},
 	}
 
 	method := Method{
 		Name:    "add",
 		Desc:    "description",
 		Args:    args,
-		Returns: Return{AbiType: "uint32", Desc: "description"},
+		Returns: Return{Type: "uint32", Desc: "description"},
 	}
 
 	expected := `{"name":"add","desc":"description","args":[{"name":"0","type":"uint32","desc":"description"},{"name":"1","type":"uint32","desc":"description"}],"returns":{"type":"uint32","desc":"description"}}`
@@ -180,15 +180,15 @@ func TestEncodeJsonMethodWithDescription(t *testing.T) {
 
 func TestEncodeJsonInterface(t *testing.T) {
 	args := []Arg{
-		{Name: "0", AbiType: "uint32", Desc: ""},
-		{Name: "1", AbiType: "uint32", Desc: ""},
+		{Name: "0", Type: "uint32", Desc: ""},
+		{Name: "1", Type: "uint32", Desc: ""},
 	}
 
 	method := Method{
 		Name:    "add",
 		Desc:    "",
 		Args:    args,
-		Returns: Return{AbiType: "uint32", Desc: ""},
+		Returns: Return{Type: "uint32", Desc: ""},
 	}
 
 	interfaceObject := Interface{
@@ -205,15 +205,15 @@ func TestEncodeJsonInterface(t *testing.T) {
 
 func TestEncodeJsonInterfaceWithDescription(t *testing.T) {
 	args := []Arg{
-		{Name: "0", AbiType: "uint32", Desc: "description"},
-		{Name: "1", AbiType: "uint32", Desc: "description"},
+		{Name: "0", Type: "uint32", Desc: "description"},
+		{Name: "1", Type: "uint32", Desc: "description"},
 	}
 
 	method := Method{
 		Name:    "add",
 		Desc:    "description",
 		Args:    args,
-		Returns: Return{AbiType: "uint32", Desc: "description"},
+		Returns: Return{Type: "uint32", Desc: "description"},
 	}
 
 	interfaceObject := Interface{
@@ -230,24 +230,26 @@ func TestEncodeJsonInterfaceWithDescription(t *testing.T) {
 
 func TestEncodeJsonContract(t *testing.T) {
 	args := []Arg{
-		{Name: "0", AbiType: "uint32", Desc: ""},
-		{Name: "1", AbiType: "uint32", Desc: ""},
+		{Name: "0", Type: "uint32", Desc: ""},
+		{Name: "1", Type: "uint32", Desc: ""},
 	}
 
 	method := Method{
 		Name:    "add",
 		Desc:    "",
 		Args:    args,
-		Returns: Return{AbiType: "uint32", Desc: ""},
+		Returns: Return{Type: "uint32", Desc: ""},
 	}
+
+	network := ContractNetworkInfo{AppID: 123}
 
 	contract := Contract{
-		Name:    "contract",
-		AppId:   123,
-		Methods: []Method{method},
+		Name:     "contract",
+		Networks: map[string]ContractNetworkInfo{"genesis hash": network},
+		Methods:  []Method{method},
 	}
 
-	expected := `{"name":"contract","appId":123,"methods":[{"name":"add","args":[{"name":"0","type":"uint32"},{"name":"1","type":"uint32"}],"returns":{"type":"uint32"}}]}`
+	expected := `{"name":"contract","networks":{"genesis hash":{"appID":123}},"methods":[{"name":"add","args":[{"name":"0","type":"uint32"},{"name":"1","type":"uint32"}],"returns":{"type":"uint32"}}]}`
 
 	jsonContract, err := json.Marshal(contract)
 	require.NoError(t, err)
@@ -256,24 +258,27 @@ func TestEncodeJsonContract(t *testing.T) {
 
 func TestEncodeJsonContractWithDescription(t *testing.T) {
 	args := []Arg{
-		{Name: "0", AbiType: "uint32", Desc: "description"},
-		{Name: "1", AbiType: "uint32", Desc: "description"},
+		{Name: "0", Type: "uint32", Desc: "description"},
+		{Name: "1", Type: "uint32", Desc: "description"},
 	}
 
 	method := Method{
 		Name:    "add",
 		Desc:    "description",
 		Args:    args,
-		Returns: Return{AbiType: "uint32", Desc: "description"},
+		Returns: Return{Type: "uint32", Desc: "description"},
 	}
+
+	network := ContractNetworkInfo{AppID: 123}
 
 	contract := Contract{
-		Name:    "contract",
-		AppId:   123,
-		Methods: []Method{method},
+		Name:     "contract",
+		Desc:     "description for contract",
+		Networks: map[string]ContractNetworkInfo{"genesis hash": network},
+		Methods:  []Method{method},
 	}
 
-	expected := `{"name":"contract","appId":123,"methods":[{"name":"add","desc":"description","args":[{"name":"0","type":"uint32","desc":"description"},{"name":"1","type":"uint32","desc":"description"}],"returns":{"type":"uint32","desc":"description"}}]}`
+	expected := `{"name":"contract","desc":"description for contract","networks":{"genesis hash":{"appID":123}},"methods":[{"name":"add","desc":"description","args":[{"name":"0","type":"uint32","desc":"description"},{"name":"1","type":"uint32","desc":"description"}],"returns":{"type":"uint32","desc":"description"}}]}`
 
 	jsonContract, err := json.Marshal(contract)
 	require.NoError(t, err)

--- a/abi/interactions_test.go
+++ b/abi/interactions_test.go
@@ -8,15 +8,18 @@ import (
 )
 
 func TestMethodFromSignature(t *testing.T) {
+	Uint32, err := TypeOf("uint32")
+	require.NoError(t, err)
+
 	expectedArgs := []Arg{
-		{Name: "", Type: "uint32", Desc: ""},
-		{Name: "", Type: "uint32", Desc: ""},
+		{Name: "", Type: "uint32", typeObject: &Uint32, Desc: ""},
+		{Name: "", Type: "uint32", typeObject: &Uint32, Desc: ""},
 	}
 	expected := Method{
 		Name:    "add",
 		Desc:    "",
 		Args:    expectedArgs,
-		Returns: Return{Type: "uint32", Desc: ""},
+		Returns: Return{Type: "uint32", typeObject: &Uint32, Desc: ""},
 	}
 
 	methodSig := "add(uint32,uint32)uint32"
@@ -27,15 +30,24 @@ func TestMethodFromSignature(t *testing.T) {
 }
 
 func TestMethodFromSignatureWithTuple(t *testing.T) {
+	Uint32, err := TypeOf("uint32")
+	require.NoError(t, err)
+
+	Uint32Tuple, err := TypeOf("(uint32,uint32)")
+	require.NoError(t, err)
+
+	Uint32TupleTuple, err := TypeOf("(uint32,(uint32,uint32))")
+	require.NoError(t, err)
+
 	expectedArgs := []Arg{
-		{Name: "", Type: "(uint32,(uint32,uint32))", Desc: ""},
-		{Name: "", Type: "uint32", Desc: ""},
+		{Name: "", Type: "(uint32,(uint32,uint32))", typeObject: &Uint32TupleTuple, Desc: ""},
+		{Name: "", Type: "uint32", typeObject: &Uint32, Desc: ""},
 	}
 	expected := Method{
 		Name:    "add",
 		Desc:    "",
 		Args:    expectedArgs,
-		Returns: Return{Type: "(uint32,uint32)", Desc: ""},
+		Returns: Return{Type: "(uint32,uint32)", typeObject: &Uint32Tuple, Desc: ""},
 	}
 
 	methodSig := "add((uint32,(uint32,uint32)),uint32)(uint32,uint32)"
@@ -46,9 +58,12 @@ func TestMethodFromSignatureWithTuple(t *testing.T) {
 }
 
 func TestMethodFromSignatureWithVoidReturn(t *testing.T) {
+	Uint32, err := TypeOf("uint32")
+	require.NoError(t, err)
+
 	expectedArgs := []Arg{
-		{Name: "", Type: "uint32", Desc: ""},
-		{Name: "", Type: "uint32", Desc: ""},
+		{Name: "", Type: "uint32", typeObject: &Uint32, Desc: ""},
+		{Name: "", Type: "uint32", typeObject: &Uint32, Desc: ""},
 	}
 	expected := Method{
 		Name:    "add",

--- a/future/atomicTransactionComposer.go
+++ b/future/atomicTransactionComposer.go
@@ -13,10 +13,11 @@ import (
 	"github.com/algorand/go-algorand-sdk/types"
 )
 
-// abiReturnHash is the 4-byte prefix for logged return values
+// abiReturnHash is the 4-byte prefix for logged return values, from https://github.com/algorandfoundation/ARCs/blob/main/ARCs/arc-0004.md#standard-format
 var abiReturnHash = []byte{0x15, 0x1f, 0x7c, 0x75}
 
-// maxAppArgs is the maximum number of arguments for an application call transaction
+// maxAppArgs is the maximum number of arguments for an application call transaction at the time
+// ARC-4 was created
 const maxAppArgs = 16
 
 // The tuple threshold is maxAppArgs, minus 1 for the method selector in the first app arg,
@@ -305,7 +306,8 @@ func (atc *AtomicTransactionComposer) AddMethodCall(params AddMethodCallParams) 
 
 	// Up to 16 app arguments can be passed to app call. First is reserved for method selector,
 	// and the rest are for method call arguments. But if more than 15 method call arguments
-	// are present, then the 14th+ are placed in a tuple in the last app argument slot
+	// are present, then the method arguments after the 14th are placed in a tuple in the last app
+	// argument slot
 	if len(basicArgValues) > maxAppArgs-1 {
 		typesForTuple := make([]abi.Type, len(basicArgTypes)-methodArgsTupleThreshold)
 		copy(typesForTuple, basicArgTypes[methodArgsTupleThreshold:])

--- a/future/atomicTransactionComposer_test.go
+++ b/future/atomicTransactionComposer_test.go
@@ -148,16 +148,10 @@ func TestAddMethodCall(t *testing.T) {
 
 	err = atc.AddMethodCall(
 		AddMethodCallParams{
-			0,
-			method,
-			nil,
-			addr,
-			types.SuggestedParams{},
-			types.NoOpOC,
-			[]byte{},
-			[32]byte{},
-			addr,
-			txSigner,
+			AppID:  4,
+			Method: method,
+			Sender: addr,
+			Signer: txSigner,
 		})
 	require.NoError(t, err)
 	require.Equal(t, atc.GetStatus(), BUILDING)
@@ -203,10 +197,8 @@ func TestGatherSignatures(t *testing.T) {
 	require.Equal(t, atc.GetStatus(), SIGNED)
 	require.Equal(t, len(sigs), 1)
 
-	tx.Group, err = crypto.ComputeGroupID([]types.Transaction{tx})
-	require.NoError(t, err)
 	txWithSigners, _ := atc.BuildGroup()
-	require.Equal(t, tx.Group, txWithSigners[0].Txn.Group)
+	require.Equal(t, types.Digest{}, txWithSigners[0].Txn.Group)
 
 	_, expectedSig, err := crypto.SignTransaction(account.PrivateKey, tx)
 	require.NoError(t, err)

--- a/test/applications_integration_test.go
+++ b/test/applications_integration_test.go
@@ -7,13 +7,13 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/cucumber/godog"
 
-	"github.com/algorand/go-algorand-sdk/abi"
 	"github.com/algorand/go-algorand-sdk/client/v2/algod"
 	"github.com/algorand/go-algorand-sdk/client/v2/common/models"
 	"github.com/algorand/go-algorand-sdk/crypto"
@@ -520,51 +520,52 @@ func iExecuteTheCurrentTransactionGroupWithTheComposer() error {
 	return err
 }
 
-func theAppShouldHaveReturned(expectedResults string) error {
-	var expected []string
-	if expectedResults == "" {
-		expected = append(expected, "")
-	} else {
-		expected = strings.Split(expectedResults, ",")
+func theAppShouldHaveReturned(commaSeparatedB64Results string) error {
+	b64ExpectedResults := strings.Split(commaSeparatedB64Results, ",")
+
+	if len(b64ExpectedResults) != len(results) {
+		return fmt.Errorf("length of expected results doesn't match actual: %d != %d", len(b64ExpectedResults), len(results))
 	}
 
-	if len(expected) != len(results) {
-		return fmt.Errorf("length of expected results doesn't match actual: %d != %d", len(expected), len(results))
+	if len(txComposerMethods) != len(results) {
+		return fmt.Errorf("length of composer's methods doesn't match results: %d != %d", len(txComposerMethods), len(results))
 	}
 
-	for i, expectedResult := range expected {
+	for i, b64ExpectedResult := range b64ExpectedResults {
+		expectedResult, err := base64.StdEncoding.DecodeString(b64ExpectedResult)
+		if err != nil {
+			return err
+		}
+
 		actualResult := results[i]
+		method := txComposerMethods[i]
+
 		if actualResult.DecodeError != nil {
 			return actualResult.DecodeError
 		}
 
-		if abiMethod.Returns.AbiType == "void" {
-			if expectedResult != "" {
-				return fmt.Errorf("found unexpected return value from void method")
+		if !bytes.Equal(actualResult.RawReturnValue, expectedResult) {
+			return fmt.Errorf("Actual result does not match expected result. Actual: %s\n", base64.RawStdEncoding.EncodeToString(actualResult.RawReturnValue))
+		}
+
+		if method.Returns.IsVoid() {
+			if len(expectedResult) > 0 {
+				return fmt.Errorf("Expected result should be empty")
 			}
 			continue
 		}
 
-		expectedBytes, err := base64.StdEncoding.DecodeString(expectedResult)
+		abiReturnType, err := method.Returns.GetTypeObject()
 		if err != nil {
 			return err
 		}
 
-		abiReturnType, err := abi.TypeOf(abiMethod.Returns.AbiType)
+		expectedValue, err := abiReturnType.Decode(expectedResult)
 		if err != nil {
 			return err
 		}
 
-		expectedValue, err := abiReturnType.Decode(expectedBytes)
-		if err != nil {
-			return err
-		}
-
-		if string(expectedBytes) != string(actualResult.RawReturnValue) {
-			return fmt.Errorf("the expected raw bytes for the result don't match the actual result")
-		}
-
-		if expectedValue != actualResult.ReturnValue {
+		if !reflect.DeepEqual(expectedValue, actualResult.ReturnValue) {
 			return fmt.Errorf("the decoded expected value doesn't match the actual result")
 		}
 	}


### PR DESCRIPTION
- [x] Add reference type support
- [x] Return error if transaction type argument does not match transaction argument type
- [x] AtomicTransactionComposer does not assign group ID if there's only 1 transaction in the group
- [x] AtomicTransactionComposer's `Execute` methods updates status to submitted before waiting for txn confirmation
- [x] Changes from https://github.com/algorandfoundation/ARCs/pull/53
  - [x] Don't tuple last argument when length is 15
  - [x] Modify `Contract` class to have `Networks` field
- [x] Add Contract and Interface descriptions, from  https://github.com/algorandfoundation/ARCs/pull/55
- [x] Changes from https://github.com/algorandfoundation/ARCs/pull/57
  - [x] AtomicTransactionComposer only checks the last log for a return value
  - [x] App creation and update transactions are supported in ABI method calls
- [x] Other minor changes
  - [x] Make comments use `//` and add more comments
  - [x] Add convenience functions `IsTransactionType` and `IsReferenceType`
  - [x] Add convenience methods to `Arg` and `Return` to check type information and get `abi.Type` value

Closes #268, closes #260 

Note: I wanted to update the go-algorand package to use additional ABI functions that were defined there, but I'm unable to update past this commit: https://github.com/algorand/go-algorand/commit/d3bbe62caa11a2608c318919122457d4512045c5, the reason being it references the package `github.com/algorand/go-algorand/data/basics` (which in turn references crypto packages with C dependencies) from `github.com/algorand/go-algorand/data/abi`, which breaks the current build. I will make a separate issue for this in go-algorand.