### PR TITLE
Add app creator to dryrun request

### DIFF
--- a/future/dryrun.go
+++ b/future/dryrun.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/algorand/go-algorand-sdk/client/v2/algod"
 	"github.com/algorand/go-algorand-sdk/client/v2/common/models"
+	"github.com/algorand/go-algorand-sdk/crypto"
 	"github.com/algorand/go-algorand-sdk/types"
 )
 
@@ -61,6 +62,7 @@ func CreateDryrun(client *algod.Client, txns []types.SignedTxn, dr *models.Dryru
 			})
 		} else {
 			apps = append(apps, t.Txn.ApplicationID)
+			accts = append(accts, crypto.GetApplicationAddress(uint64(t.Txn.ApplicationID)))
 		}
 	}
 

--- a/future/dryrun.go
+++ b/future/dryrun.go
@@ -100,7 +100,7 @@ func CreateDryrun(client *algod.Client, txns []types.SignedTxn, dr *models.Dryru
 
 		creator, err := types.DecodeAddress(appInfo.Params.Creator)
 		if err != nil {
-			return drr, fmt.Errorf("faiiled to decode creator address %s: %+v", appInfo.Params.Creator, err)
+			return drr, fmt.Errorf("failed to decode creator address %s: %+v", appInfo.Params.Creator, err)
 		}
 		accts = append(accts, creator)
 

--- a/future/dryrun.go
+++ b/future/dryrun.go
@@ -9,6 +9,10 @@ import (
 	"github.com/algorand/go-algorand-sdk/types"
 )
 
+const (
+	defaultAppId uint64 = 1380011588
+)
+
 // CreateDryrun creates a DryrunRequest object from a client and slice of SignedTxn objects and a default configuration
 // Passed in as a pointer to a DryrunRequest object to use for extra parameters
 func CreateDryrun(client algod.Client, txns []types.SignedTxn, dr *models.DryrunRequest) (drr models.DryrunRequest, err error) {
@@ -39,9 +43,8 @@ func CreateDryrun(client algod.Client, txns []types.SignedTxn, dr *models.Dryrun
 		assets = append(assets, t.Txn.ForeignAssets...)
 
 		if t.Txn.ApplicationID == 0 {
-			appId := 1 //TODO: make the magic number?
 			drr.Apps = append(drr.Apps, models.Application{
-				Id: uint64(appId),
+				Id: defaultAppId,
 				Params: models.ApplicationParams{
 					Creator:           t.Txn.Sender.String(),
 					ApprovalProgram:   t.Txn.ApprovalProgram,

--- a/future/dryrun.go
+++ b/future/dryrun.go
@@ -76,10 +76,12 @@ func CreateDryrun(client *algod.Client, txns []types.SignedTxn, dr *models.Dryru
 		if err != nil {
 			return drr, fmt.Errorf("failed to get asset %d: %+v", assetId, err)
 		}
+
 		addr, err := types.DecodeAddress(assetInfo.Params.Creator)
 		if err != nil {
 			return drr, fmt.Errorf("failed to decode creator adddress %s: %+v", assetInfo.Params.Creator, err)
 		}
+
 		accts = append(accts, addr)
 		seenAssets[assetId] = true
 	}
@@ -89,11 +91,19 @@ func CreateDryrun(client *algod.Client, txns []types.SignedTxn, dr *models.Dryru
 		if _, ok := seenApps[appId]; ok {
 			continue
 		}
+
 		appInfo, err := client.GetApplicationByID(uint64(appId)).Do(ctx)
 		if err != nil {
 			return drr, fmt.Errorf("failed to get application %d: %+v", appId, err)
 		}
 		drr.Apps = append(drr.Apps, appInfo)
+
+		creator, err := types.DecodeAddress(appInfo.Params.Creator)
+		if err != nil {
+			return drr, fmt.Errorf("faiiled to decode creator address %s: %+v", appInfo.Params.Creator, err)
+		}
+		accts = append(accts, creator)
+
 		seenApps[appId] = true
 	}
 

--- a/future/dryrun.go
+++ b/future/dryrun.go
@@ -1,0 +1,96 @@
+package future
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/algorand/go-algorand-sdk/client/v2/algod"
+	"github.com/algorand/go-algorand-sdk/client/v2/common/models"
+	"github.com/algorand/go-algorand-sdk/types"
+)
+
+// CreateDryrun creates a DryrunRequest object from a client and slice of SignedTxn objects and a default configuration
+// Passed in as a pointer to a DryrunRequest object to use for extra parameters
+func CreateDryrun(client algod.Client, txns []types.SignedTxn, dr *models.DryrunRequest) (drr models.DryrunRequest, err error) {
+	var (
+		apps   []types.AppIndex
+		assets []types.AssetIndex
+		accts  []types.Address
+	)
+
+	drr.Txns = txns
+
+	if dr != nil {
+		drr.LatestTimestamp = dr.LatestTimestamp
+		drr.Round = dr.Round
+		drr.ProtocolVersion = dr.ProtocolVersion
+		drr.Sources = dr.Sources
+	}
+
+	for _, t := range txns {
+		if t.Txn.Type != types.ApplicationCallTx {
+			continue
+		}
+
+		accts = append(accts, t.Txn.Sender)
+
+		accts = append(accts, t.Txn.Accounts...)
+		apps = append(apps, t.Txn.ForeignApps...)
+		assets = append(assets, t.Txn.ForeignAssets...)
+
+		if t.Txn.ApplicationID == 0 {
+			appId := 1 //TODO: make the magic number?
+			drr.Apps = append(drr.Apps, models.Application{
+				Id: uint64(appId),
+				Params: models.ApplicationParams{
+					Creator:           t.Txn.Sender.String(),
+					ApprovalProgram:   t.Txn.ApprovalProgram,
+					ClearStateProgram: t.Txn.ClearStateProgram,
+					LocalStateSchema: models.ApplicationStateSchema{
+						NumByteSlice: t.Txn.LocalStateSchema.NumByteSlice,
+						NumUint:      t.Txn.LocalStateSchema.NumUint,
+					},
+					GlobalStateSchema: models.ApplicationStateSchema{
+						NumByteSlice: t.Txn.GlobalStateSchema.NumByteSlice,
+						NumUint:      t.Txn.GlobalStateSchema.NumUint,
+					},
+				},
+			})
+		} else {
+			apps = append(apps, t.Txn.ApplicationID)
+		}
+	}
+
+	for _, assetId := range assets {
+		assetInfo, err := client.GetAssetByID(uint64(assetId)).Do(context.Background())
+		if err != nil {
+			return drr, fmt.Errorf("failed to get asset %d: %+v", assetId, err)
+		}
+
+		addr, err := types.DecodeAddress(assetInfo.Params.Creator)
+		if err != nil {
+			return drr, fmt.Errorf("failed to decode creator adddress %s: %+v", assetInfo.Params.Creator, err)
+		}
+		accts = append(accts, addr)
+	}
+
+	for _, appId := range apps {
+		appInfo, err := client.GetApplicationByID(uint64(appId)).Do(context.Background())
+		if err != nil {
+			return drr, fmt.Errorf("failed to get application %d: %+v", appId, err)
+		}
+
+		drr.Apps = append(drr.Apps, appInfo)
+	}
+
+	for _, acct := range accts {
+		acctInfo, err := client.AccountInformation(acct.String()).Do(context.Background())
+		if err != nil {
+			return drr, fmt.Errorf("failed to get application %s: %+v", acct, err)
+		}
+
+		drr.Accounts = append(drr.Accounts, acctInfo)
+	}
+
+	return
+}

--- a/future/dryrun.go
+++ b/future/dryrun.go
@@ -16,7 +16,7 @@ const (
 
 // CreateDryrun creates a DryrunRequest object from a client and slice of SignedTxn objects and a default configuration
 // Passed in as a pointer to a DryrunRequest object to use for extra parameters
-func CreateDryrun(client *algod.Client, txns []types.SignedTxn, dr *models.DryrunRequest) (drr models.DryrunRequest, err error) {
+func CreateDryrun(client *algod.Client, txns []types.SignedTxn, dr *models.DryrunRequest, ctx context.Context) (drr models.DryrunRequest, err error) {
 	var (
 		apps   []types.AppIndex
 		assets []types.AssetIndex
@@ -72,7 +72,7 @@ func CreateDryrun(client *algod.Client, txns []types.SignedTxn, dr *models.Dryru
 			continue
 		}
 
-		assetInfo, err := client.GetAssetByID(uint64(assetId)).Do(context.Background())
+		assetInfo, err := client.GetAssetByID(uint64(assetId)).Do(ctx)
 		if err != nil {
 			return drr, fmt.Errorf("failed to get asset %d: %+v", assetId, err)
 		}
@@ -89,7 +89,7 @@ func CreateDryrun(client *algod.Client, txns []types.SignedTxn, dr *models.Dryru
 		if _, ok := seenApps[appId]; ok {
 			continue
 		}
-		appInfo, err := client.GetApplicationByID(uint64(appId)).Do(context.Background())
+		appInfo, err := client.GetApplicationByID(uint64(appId)).Do(ctx)
 		if err != nil {
 			return drr, fmt.Errorf("failed to get application %d: %+v", appId, err)
 		}
@@ -102,7 +102,7 @@ func CreateDryrun(client *algod.Client, txns []types.SignedTxn, dr *models.Dryru
 		if _, ok := seenAccts[acct]; ok {
 			continue
 		}
-		acctInfo, err := client.AccountInformation(acct.String()).Do(context.Background())
+		acctInfo, err := client.AccountInformation(acct.String()).Do(ctx)
 		if err != nil {
 			return drr, fmt.Errorf("failed to get application %s: %+v", acct, err)
 		}

--- a/future/dryrun.go
+++ b/future/dryrun.go
@@ -15,7 +15,7 @@ const (
 
 // CreateDryrun creates a DryrunRequest object from a client and slice of SignedTxn objects and a default configuration
 // Passed in as a pointer to a DryrunRequest object to use for extra parameters
-func CreateDryrun(client algod.Client, txns []types.SignedTxn, dr *models.DryrunRequest) (drr models.DryrunRequest, err error) {
+func CreateDryrun(client *algod.Client, txns []types.SignedTxn, dr *models.DryrunRequest) (drr models.DryrunRequest, err error) {
 	var (
 		apps   []types.AppIndex
 		assets []types.AssetIndex


### PR DESCRIPTION
When doing an appGlobalGetEx the values are extracted from the balance record of the app creator. If the app creator is not in the balance records passed in dryrun request the eval will report the application is not found

