### PR TITLE
BugFix for ATC failing to add an golang fixed-length array

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/algorand/go-algorand-sdk
 go 1.16
 
 require (
-	github.com/algorand/go-algorand v0.0.0-20220322182955-997bd8641cbb
+	github.com/algorand/go-algorand v0.0.0-20220323144801-17c0feef002f
 	github.com/algorand/go-codec/codec v1.1.8
 	github.com/cucumber/godog v0.8.1
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/algorand/falcon v0.0.0-20220130164023-c9e1d466f123/go.mod h1:OkQyHlGvS0kLNcIWbC21/uQcnbfwSOQm+wiqWwBG9pQ=
 github.com/algorand/go-algorand v0.0.0-20220322182955-997bd8641cbb h1:OvyvEh+PUf4mv+wHo9YM1vSv4DBrCoJt9n/J2g0th/Q=
 github.com/algorand/go-algorand v0.0.0-20220322182955-997bd8641cbb/go.mod h1:ehGHRKxrRgN0fF+vm6kHLykiQ1ana3qc52N5UQzkFPM=
+github.com/algorand/go-algorand v0.0.0-20220323144801-17c0feef002f h1:TiemycRO/Cg0I8XlLlXf2n2gP6sxL5LEObhJOdveKdg=
+github.com/algorand/go-algorand v0.0.0-20220323144801-17c0feef002f/go.mod h1:ehGHRKxrRgN0fF+vm6kHLykiQ1ana3qc52N5UQzkFPM=
 github.com/algorand/go-codec v1.1.8 h1:XDSreeeZY8gMst6Edz4RBkl08/DGMJOeHYkoXL2B7wI=
 github.com/algorand/go-codec v1.1.8/go.mod h1:XhzVs6VVyWMLu6cApb9/192gBjGRVGm5cX5j203Heg4=
 github.com/algorand/go-codec/codec v1.1.8 h1:lsFuhcOH2LiEhpBH3BVUUkdevVmwCRyvb7FCAAPeY6U=


### PR DESCRIPTION
## Description

What Shai mentioned in #302 is caused by a bug in `data/abi` in go-algorand, which go-algorand-sdk depends on.

The bugfix PR in go-algorand is https://github.com/algorand/go-algorand/pull/3823, and this PR raises the SDK's go-algorand version to the bug-fixed one.

Closes #302 