### PR TITLE
Refresh generated sources

### DIFF
--- a/client/v2/algod/algod.go
+++ b/client/v2/algod/algod.go
@@ -124,6 +124,10 @@ func (c *Client) TealCompile(source []byte) *TealCompile {
 	return &TealCompile{c: c, source: source}
 }
 
+func (c *Client) TealDisassemble(source []byte) *TealDisassemble {
+	return &TealDisassemble{c: c, source: source}
+}
+
 func (c *Client) TealDryrun(request models.DryrunRequest) *TealDryrun {
 	return &TealDryrun{c: c, request: request}
 }

--- a/client/v2/algod/getProof.go
+++ b/client/v2/algod/getProof.go
@@ -13,6 +13,11 @@ type GetProofParams struct {
 
 	// Format configures whether the response object is JSON or MessagePack encoded.
 	Format string `url:"format,omitempty"`
+
+	// Hashtype the type of hash function used to create the proof, must be one of:
+	// * sha512_256
+	// * sha256
+	Hashtype string `url:"hashtype,omitempty"`
 }
 
 // GetProof get a Merkle proof for a transaction in a block.
@@ -23,6 +28,14 @@ type GetProof struct {
 	txid  string
 
 	p GetProofParams
+}
+
+// Hashtype the type of hash function used to create the proof, must be one of:
+// * sha512_256
+// * sha256
+func (s *GetProof) Hashtype(Hashtype string) *GetProof {
+	s.p.Hashtype = Hashtype
+	return s
 }
 
 // Do performs the HTTP request

--- a/client/v2/algod/tealCompile.go
+++ b/client/v2/algod/tealCompile.go
@@ -7,14 +7,31 @@ import (
 	"github.com/algorand/go-algorand-sdk/client/v2/common/models"
 )
 
+// TealCompileParams contains all of the query parameters for url serialization.
+type TealCompileParams struct {
+
+	// Sourcemap when set to `true`, returns the source map of the program as a JSON.
+	// Defaults to `false`.
+	Sourcemap bool `url:"sourcemap,omitempty"`
+}
+
 // TealCompile given TEAL source code in plain text, return base64 encoded program
 // bytes and base32 SHA512_256 hash of program bytes (Address style). This endpoint
-// is only enabled when a node's configureation file sets EnableDeveloperAPI to
+// is only enabled when a node's configuration file sets EnableDeveloperAPI to
 // true.
 type TealCompile struct {
 	c *Client
 
 	source []byte
+
+	p TealCompileParams
+}
+
+// Sourcemap when set to `true`, returns the source map of the program as a JSON.
+// Defaults to `false`.
+func (s *TealCompile) Sourcemap(Sourcemap bool) *TealCompile {
+	s.p.Sourcemap = Sourcemap
+	return s
 }
 
 // Do performs the HTTP request

--- a/client/v2/algod/tealDisassemble.go
+++ b/client/v2/algod/tealDisassemble.go
@@ -1,0 +1,23 @@
+package algod
+
+import (
+	"context"
+
+	"github.com/algorand/go-algorand-sdk/client/v2/common"
+	"github.com/algorand/go-algorand-sdk/client/v2/common/models"
+)
+
+// TealDisassemble given the program bytes, return the TEAL source code in plain
+// text. This endpoint is only enabled when a node's configuration file sets
+// EnableDeveloperAPI to true.
+type TealDisassemble struct {
+	c *Client
+
+	source []byte
+}
+
+// Do performs the HTTP request
+func (s *TealDisassemble) Do(ctx context.Context, headers ...*common.Header) (response models.DisassembleResponse, err error) {
+	err = s.c.get(ctx, &response, "/v2/teal/disassemble", nil, headers)
+	return
+}

--- a/client/v2/algod/tealDryrun.go
+++ b/client/v2/algod/tealDryrun.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TealDryrun executes TEAL program(s) in context and returns debugging information
-// about the execution. This endpoint is only enabled when a node's configureation
+// about the execution. This endpoint is only enabled when a node's configuration
 // file sets EnableDeveloperAPI to true.
 type TealDryrun struct {
 	c *Client

--- a/client/v2/common/models/account.go
+++ b/client/v2/common/models/account.go
@@ -54,11 +54,6 @@ type Account struct {
 	// Deleted whether or not this account is currently closed.
 	Deleted bool `json:"deleted,omitempty"`
 
-	// Hashtype the type of hash function used to create the proof, must be one of:
-	// * sha512_256
-	// * sha256
-	Hashtype string `json:"hashtype,omitempty"`
-
 	// Participation accountParticipation describes the parameters used by this account
 	// in consensus protocol.
 	Participation AccountParticipation `json:"participation,omitempty"`

--- a/client/v2/common/models/account.go
+++ b/client/v2/common/models/account.go
@@ -54,6 +54,11 @@ type Account struct {
 	// Deleted whether or not this account is currently closed.
 	Deleted bool `json:"deleted,omitempty"`
 
+	// Hashtype the type of hash function used to create the proof, must be one of:
+	// * sha512_256
+	// * sha256
+	Hashtype string `json:"hashtype,omitempty"`
+
 	// Participation accountParticipation describes the parameters used by this account
 	// in consensus protocol.
 	Participation AccountParticipation `json:"participation,omitempty"`

--- a/client/v2/common/models/compile_response.go
+++ b/client/v2/common/models/compile_response.go
@@ -7,4 +7,7 @@ type CompileResponse struct {
 
 	// Result base64 encoded program bytes
 	Result string `json:"result"`
+
+	// Sourcemap jSON of the source map
+	Sourcemap *map[string]interface{} `json:"sourcemap,omitempty"`
 }

--- a/client/v2/common/models/disassemble_response.go
+++ b/client/v2/common/models/disassemble_response.go
@@ -1,0 +1,7 @@
+package models
+
+// DisassembleResponse teal disassembly Result
+type DisassembleResponse struct {
+	// Result disassembled Teal code
+	Result string `json:"result"`
+}

--- a/client/v2/common/models/proof_response.go
+++ b/client/v2/common/models/proof_response.go
@@ -3,8 +3,8 @@ package models
 // ProofResponse proof of transaction in a block.
 type ProofResponse struct {
 	// Hashtype the type of hash function used to create the proof, must be one of:
-	// * sumhash
 	// * sha512_256
+	// * sha256
 	Hashtype string `json:"hashtype,omitempty"`
 
 	// Idx index of the transaction in the block's payset.

--- a/client/v2/indexer/lookupAccountTransactions.go
+++ b/client/v2/indexer/lookupAccountTransactions.go
@@ -70,7 +70,8 @@ type LookupAccountTransactionsParams struct {
 	TXID string `url:"txid,omitempty"`
 }
 
-// LookupAccountTransactions lookup account transactions.
+// LookupAccountTransactions lookup account transactions. Transactions are returned
+// newest to oldest.
 type LookupAccountTransactions struct {
 	c *Client
 

--- a/client/v2/indexer/lookupAssetTransactions.go
+++ b/client/v2/indexer/lookupAssetTransactions.go
@@ -80,7 +80,8 @@ type LookupAssetTransactionsParams struct {
 	TXID string `url:"txid,omitempty"`
 }
 
-// LookupAssetTransactions lookup transactions for an asset.
+// LookupAssetTransactions lookup transactions for an asset. Transactions are
+// returned oldest to newest.
 type LookupAssetTransactions struct {
 	c *Client
 

--- a/client/v2/indexer/searchForTransactions.go
+++ b/client/v2/indexer/searchForTransactions.go
@@ -85,7 +85,9 @@ type SearchForTransactionsParams struct {
 	TXID string `url:"txid,omitempty"`
 }
 
-// SearchForTransactions search for transactions.
+// SearchForTransactions search for transactions. Transactions are returned oldest
+// to newest unless the address parameter is used, in which case results are
+// returned newest to oldest.
 type SearchForTransactions struct {
 	c *Client
 


### PR DESCRIPTION
Regenerates source using https://github.com/algorand/generator/pull/30 to fix the data type issue identified in https://github.com/algorand/go-algorand-sdk/pull/316#discussion_r872584788.

Diff generated via the following command from _generator_ home: `sh scripts/generate_go.sh`.