### PR TITLE
Boxes:  Demonstrate generator generates broken model

### DIFF
--- a/client/v2/algod/algod.go
+++ b/client/v2/algod/algod.go
@@ -116,6 +116,10 @@ func (c *Client) GetApplicationByID(applicationId uint64) *GetApplicationByID {
 	return &GetApplicationByID{c: c, applicationId: applicationId}
 }
 
+func (c *Client) GetApplicationBoxes(applicationId uint64) *GetApplicationBoxes {
+	return &GetApplicationBoxes{c: c, applicationId: applicationId}
+}
+
 func (c *Client) GetApplicationBoxByName(applicationId uint64) *GetApplicationBoxByName {
 	return &GetApplicationBoxByName{c: c, applicationId: applicationId}
 }

--- a/client/v2/algod/getApplicationBoxes.go
+++ b/client/v2/algod/getApplicationBoxes.go
@@ -1,0 +1,40 @@
+package algod
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/algorand/go-algorand-sdk/client/v2/common"
+	"github.com/algorand/go-algorand-sdk/client/v2/common/models"
+)
+
+// GetApplicationBoxesParams contains all of the query parameters for url serialization.
+type GetApplicationBoxesParams struct {
+
+	// Max max number of box names to return. If max is not set, or max == 0, returns
+	// all box-names.
+	Max uint64 `url:"max,omitempty"`
+}
+
+// GetApplicationBoxes given an application ID, it returns the box names of that
+// application. No particular ordering is guaranteed.
+type GetApplicationBoxes struct {
+	c *Client
+
+	applicationId uint64
+
+	p GetApplicationBoxesParams
+}
+
+// Max max number of box names to return. If max is not set, or max == 0, returns
+// all box-names.
+func (s *GetApplicationBoxes) Max(Max uint64) *GetApplicationBoxes {
+	s.p.Max = Max
+	return s
+}
+
+// Do performs the HTTP request
+func (s *GetApplicationBoxes) Do(ctx context.Context, headers ...*common.Header) (response models.BoxesResponse, err error) {
+	err = s.c.get(ctx, &response, fmt.Sprintf("/v2/applications/%s/boxes", common.EscapeParams(s.applicationId)...), s.p, headers)
+	return
+}


### PR DESCRIPTION
Demonstrates _generator_ generates broken code for getting all boxes (https://github.com/algorand/go-algorand/pull/4154).  I don't intend to merge the PR.

Running `make unit` shows a struct is missing:
```
...
# github.com/algorand/go-algorand-sdk/client/v2/algod
client/v2/algod/getApplicationBoxes.go:42:92: undefined: models.BoxesResponse
...
```

go-algorand inspection shows only 1 other route that returns a top-level array:
```
~/dev/go-algorand feature/avm-box ?13 ────────────────────────────────────────────────────────────────────────────────────── 05:24:57 PM
❯ grep '"schema":' daemon/algod/api/algod.oas2.json -C5 | grep -B2 '"array"'
      "description": "A list of participation keys",
      "schema": {
        "type": "array",
--
      "description": "Box names of an application",
      "schema": {
        "type": "array",
```

Unfortunately, _listing participation keys_ does not appear to be added to the SDKs.  Leads me to believe top-level arrays have not been previously required in _generator_.