### PR TITLE
Testing: Use Dev mode network for cucumber tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ unit:
 
 integration:
 	go test $(TEST_SOURCES_NO_CUCUMBER)
-	cd test && go test -timeout 0s --godog.strict=true --godog.format=pretty --godog.tags="@algod,@assets,@auction,@kmd,@send,@indexer,@rekey,@send.keyregtxn,@dryrun,@compile,@applications.verified,@indexer.applications,@indexer.231,@abi,@c2c,@compile.sourcemap" --test.v .
+	cd test && go test -timeout 0s --godog.strict=true --godog.format=pretty --godog.tags="@algod,@assets,@auction,@kmd,@send,@indexer,@rekey_v1,@send.keyregtxn,@dryrun,@compile,@applications.verified,@indexer.applications,@indexer.231,@abi,@c2c,@compile.sourcemap" --test.v .
 
 docker-test:
 	./test/docker/run_docker.sh

--- a/test/applications_integration_test.go
+++ b/test/applications_integration_test.go
@@ -69,7 +69,7 @@ func iCreateANewTransientAccountAndFundItWithMicroalgos(microalgos int) error {
 	if err != nil {
 		return err
 	}
-	_, err = future.WaitForConfirmation(algodV2client, ltxid, 5, context.Background())
+	_, err = future.WaitForConfirmation(algodV2client, ltxid, 1, context.Background())
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func iFundTheCurrentApplicationsAddress(microalgos int) error {
 		return err
 	}
 
-	_, err = future.WaitForConfirmation(algodV2client, txid, 5, context.Background())
+	_, err = future.WaitForConfirmation(algodV2client, txid, 1, context.Background())
 	return err
 }
 
@@ -266,7 +266,7 @@ func iSignAndSubmitTheTransactionSavingTheTxidIfThereIsAnErrorItIs(expectedErr s
 }
 
 func iWaitForTheTransactionToBeConfirmed() error {
-	_, err := future.WaitForConfirmation(algodV2client, txid, 5, context.Background())
+	_, err := future.WaitForConfirmation(algodV2client, txid, 1, context.Background())
 	if err != nil {
 		return err
 	}

--- a/test/applications_integration_test.go
+++ b/test/applications_integration_test.go
@@ -69,7 +69,7 @@ func iCreateANewTransientAccountAndFundItWithMicroalgos(microalgos int) error {
 	if err != nil {
 		return err
 	}
-	_, err = future.WaitForConfirmation(algodV2client, ltxid, 2, context.Background())
+	_, err = future.WaitForConfirmation(algodV2client, ltxid, 1, context.Background())
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func iFundTheCurrentApplicationsAddress(microalgos int) error {
 		return err
 	}
 
-	_, err = future.WaitForConfirmation(algodV2client, txid, 2, context.Background())
+	_, err = future.WaitForConfirmation(algodV2client, txid, 1, context.Background())
 	return err
 }
 
@@ -266,7 +266,7 @@ func iSignAndSubmitTheTransactionSavingTheTxidIfThereIsAnErrorItIs(expectedErr s
 }
 
 func iWaitForTheTransactionToBeConfirmed() error {
-	_, err := future.WaitForConfirmation(algodV2client, txid, 2, context.Background())
+	_, err := future.WaitForConfirmation(algodV2client, txid, 1, context.Background())
 	if err != nil {
 		return err
 	}

--- a/test/applications_integration_test.go
+++ b/test/applications_integration_test.go
@@ -69,7 +69,7 @@ func iCreateANewTransientAccountAndFundItWithMicroalgos(microalgos int) error {
 	if err != nil {
 		return err
 	}
-	_, err = future.WaitForConfirmation(algodV2client, ltxid, 1, context.Background())
+	_, err = future.WaitForConfirmation(algodV2client, ltxid, 2, context.Background())
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func iFundTheCurrentApplicationsAddress(microalgos int) error {
 		return err
 	}
 
-	_, err = future.WaitForConfirmation(algodV2client, txid, 1, context.Background())
+	_, err = future.WaitForConfirmation(algodV2client, txid, 2, context.Background())
 	return err
 }
 
@@ -266,7 +266,7 @@ func iSignAndSubmitTheTransactionSavingTheTxidIfThereIsAnErrorItIs(expectedErr s
 }
 
 func iWaitForTheTransactionToBeConfirmed() error {
-	_, err := future.WaitForConfirmation(algodV2client, txid, 1, context.Background())
+	_, err := future.WaitForConfirmation(algodV2client, txid, 2, context.Background())
 	if err != nil {
 		return err
 	}

--- a/test/docker/run_docker.sh
+++ b/test/docker/run_docker.sh
@@ -5,7 +5,7 @@ set -e
 # reset test harness
 rm -rf test-harness
 rm -rf test/features
-git clone --single-branch --branch master https://github.com/algorand/algorand-sdk-testing.git test-harness
+git clone --single-branch --branch devmodenet https://github.com/algorand/algorand-sdk-testing.git test-harness
 #copy feature files into project
 mv test-harness/features test/features
 

--- a/test/docker/run_docker.sh
+++ b/test/docker/run_docker.sh
@@ -5,7 +5,7 @@ set -e
 # reset test harness
 rm -rf test-harness
 rm -rf test/features
-git clone --single-branch --branch devmodenet https://github.com/algorand/algorand-sdk-testing.git test-harness
+git clone --single-branch --branch master https://github.com/algorand/algorand-sdk-testing.git test-harness
 #copy feature files into project
 mv test-harness/features test/features
 

--- a/test/steps_test.go
+++ b/test/steps_test.go
@@ -11,6 +11,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path"
 	"reflect"
@@ -71,6 +72,7 @@ var status models.NodeStatus
 var statusAfter models.NodeStatus
 var msigExp kmd.ExportMultisigResponse
 var pk string
+var rekey string
 var accounts []string
 var e bool
 var lastRound uint64
@@ -138,6 +140,57 @@ var opt = godog.Options{
 	Format: "progress", // can define default values
 }
 
+// Dev mode helper functions
+const devModeInitialAmount = 10_000_000
+
+func initializeAccount(accountAddress string) error {
+	params, err := acl.BuildSuggestedParams()
+	if err != nil {
+		return err
+	}
+
+	txn, err = future.MakePaymentTxn(accounts[0], accountAddress, devModeInitialAmount, []byte{}, "", params)
+	if err != nil {
+		return err
+	}
+
+	res, err := kcl.SignTransaction(handle, walletPswd, txn)
+	if err != nil {
+		return err
+	}
+
+	_, err = acl.SendRawTransaction(res.SignedTransaction)
+	if err != nil {
+		return err
+	}
+	time.Sleep(500 * time.Millisecond)
+	return err
+}
+
+func selfPayTransaction() error {
+	params, err := acl.BuildSuggestedParams()
+	if err != nil {
+		return err
+	}
+
+	txn, err = future.MakePaymentTxn(accounts[0], accounts[0], uint64(rand.Intn(devModeInitialAmount*0.01)), []byte{}, "", params)
+	if err != nil {
+		return err
+	}
+
+	res, err := kcl.SignTransaction(handle, walletPswd, txn)
+	if err != nil {
+		return err
+	}
+
+	_, err = acl.SendRawTransaction(res.SignedTransaction)
+	if err != nil {
+		return err
+	}
+	time.Sleep(500 * time.Millisecond)
+	return err
+}
+
 func init() {
 	godog.BindFlags("godog.", flag.CommandLine, &opt)
 }
@@ -199,7 +252,8 @@ func FeatureContext(s *godog.Suite) {
 	s.Step("the multisig should equal the exported multisig", msigEq)
 	s.Step("I delete the multisig", deleteMsig)
 	s.Step("the multisig should not be in the wallet", msigNotInWallet)
-	s.Step("I generate a key using kmd", genKeyKmd)
+	s.Step("^I generate a key using kmd for rekeying and fund it$", genRekeyKmd)
+	s.Step("^I generate a key using kmd$", genKeyKmd)
 	s.Step("the key should be in the wallet", keyInWallet)
 	s.Step("I delete the key", deleteKey)
 	s.Step("the key should not be in the wallet", keyNotInWallet)
@@ -766,6 +820,16 @@ func genKeyKmd() error {
 	return nil
 }
 
+func genRekeyKmd() error {
+	p, err := kcl.GenerateKey(handle)
+	if err != nil {
+		return err
+	}
+	rekey = p.Address
+	initializeAccount(rekey)
+	return nil
+}
+
 func keyInWallet() error {
 	resp, err := kcl.ListKeys(handle)
 	if err != nil {
@@ -876,7 +940,8 @@ func walletInfo() error {
 	return err
 }
 
-func defaultTxn(iamt int, inote string) error {
+// Helper function for making default transactions.
+func defaultTxnWithAddress(iamt int, inote string, senderAddress string) error {
 	var err error
 	if inote != "none" {
 		note, err = base64.StdEncoding.DecodeString(inote)
@@ -891,14 +956,22 @@ func defaultTxn(iamt int, inote string) error {
 	}
 
 	amt = uint64(iamt)
-	pk = accounts[0]
+	pk = senderAddress
 	params, err := acl.BuildSuggestedParams()
 	if err != nil {
 		return err
 	}
 	lastRound = uint64(params.FirstRoundValid)
-	txn, err = future.MakePaymentTxn(accounts[0], accounts[1], amt, note, "", params)
+	txn, err = future.MakePaymentTxn(senderAddress, accounts[1], amt, note, "", params)
 	return err
+}
+
+func defaultTxn(iamt int, inote string) error {
+	return defaultTxnWithAddress(iamt, inote, accounts[0])
+}
+
+func defaultTxnRekey(iamt int, inote string) error {
+	return defaultTxnWithAddress(iamt, inote, rekey)
 }
 
 func defaultMsigTxn(iamt int, inote string) error {
@@ -997,14 +1070,15 @@ func sendMsigTxn() error {
 }
 
 func checkTxn() error {
+	time.Sleep(500 * time.Millisecond)
 	_, err := acl.PendingTransactionInformation(txid)
 	if err != nil {
 		return err
 	}
-	_, err = acl.StatusAfterBlock(lastRound + 2)
-	if err != nil {
-		return err
-	}
+	// _, err = acl.StatusAfterBlock(lastRound + 2)
+	// if err != nil {
+	// 	return err
+	// }
 	if txn.Sender.String() != "" && txn.Sender.String() != "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ" {
 		_, err = acl.TransactionInformation(txn.Sender.String(), txid)
 	} else {
@@ -1019,10 +1093,11 @@ func checkTxn() error {
 
 func txnbyID() error {
 	var err error
-	_, err = acl.StatusAfterBlock(lastRound + 2)
-	if err != nil {
-		return err
-	}
+	time.Sleep(500 * time.Millisecond)
+	// _, err = acl.StatusAfterBlock(lastRound + 2)
+	// if err != nil {
+	// 	return err
+	// }
 	_, err = acl.TransactionByID(txid)
 	return err
 }


### PR DESCRIPTION
This PR adds support for using the Dev mode network for the [SDK tests](https://github.com/algorand/algorand-sdk-testing/pull/206).