### PR TITLE
tests: Enable stpf cucumber unit tests

### DIFF
--- a/test/unit.tags
+++ b/test/unit.tags
@@ -21,6 +21,9 @@
 @unit.responses.messagepack.231
 @unit.responses.unlimited_assets
 @unit.sourcemap
+@unit.stateproof.paths
+@unit.stateproof.responses
+@unit.stateproof.responses.msgp
 @unit.tealsign
 @unit.transactions
 @unit.transactions.keyreg


### PR DESCRIPTION
Enables stateproof cucumber unit tests that were missed during initial implementation due to merge issues when converting tags to separate files.