### PR TITLE
FOR REVIEW ONLY - go-algorand-sdk v1.22.0

### DIFF
--- a/.test-env
+++ b/.test-env
@@ -3,6 +3,8 @@ SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
 SDK_TESTING_BRANCH="master"
 SDK_TESTING_HARNESS="test-harness"
 
+INSTALL_ONLY=0
+
 VERBOSE_HARNESS=0
 
 # WARNING: If set to 1, new features will be LOST when downloading the test harness.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.22.0w
+# 1.22.0
 ## What's Changed
 ## Enhancements
 * REST API: Add algod block hash endpoint, add indexer block header-only param. ([#421](https://github.com/algorand/go-algorand-sdk/pull/421))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.22.0w
+## What's Changed
+## Enhancements
+* REST API: Add algod block hash endpoint, add indexer block header-only param. ([#421](https://github.com/algorand/go-algorand-sdk/pull/421))
+
 # 1.21.0
 ## What's Changed
 ### Enhancements

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,10 @@ display-all-go-steps:
 	find test -name "*.go" | xargs grep "github.com/cucumber/godog" 2>/dev/null | cut -d: -f1 | sort | uniq | xargs grep -Eo "Step[(].[^\`]+" | awk '{sub(/:Step\(./,":")} 1' | sed -E 's/", [a-zA-Z0-9]+\)//g'
 
 harness:
-	./test-harness.sh
+	./test-harness.sh up
+
+harness-down:
+	./test-harness.sh down
 
 docker-gosdk-build:
 	echo "Building docker image from base $(GO_IMAGE)"

--- a/client/v2/algod/algod.go
+++ b/client/v2/algod/algod.go
@@ -80,6 +80,10 @@ func (c *Client) Block(round uint64) *Block {
 	return &Block{c: c, round: round}
 }
 
+func (c *Client) GetBlockHash(round uint64) *GetBlockHash {
+	return &GetBlockHash{c: c, round: round}
+}
+
 func (c *Client) GetTransactionProof(round uint64, txid string) *GetTransactionProof {
 	return &GetTransactionProof{c: c, round: round, txid: txid}
 }

--- a/client/v2/algod/getBlockHash.go
+++ b/client/v2/algod/getBlockHash.go
@@ -1,0 +1,22 @@
+package algod
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/algorand/go-algorand-sdk/client/v2/common"
+	"github.com/algorand/go-algorand-sdk/client/v2/common/models"
+)
+
+// GetBlockHash get the block hash for the block on the given round.
+type GetBlockHash struct {
+	c *Client
+
+	round uint64
+}
+
+// Do performs the HTTP request
+func (s *GetBlockHash) Do(ctx context.Context, headers ...*common.Header) (response models.BlockHashResponse, err error) {
+	err = s.c.get(ctx, &response, fmt.Sprintf("/v2/blocks/%s/hash", common.EscapeParams(s.round)...), nil, headers)
+	return
+}

--- a/client/v2/common/models/block_hash_response.go
+++ b/client/v2/common/models/block_hash_response.go
@@ -1,0 +1,7 @@
+package models
+
+// BlockHashResponse hash of a block header.
+type BlockHashResponse struct {
+	// Blockhash block header hash.
+	Blockhash string `json:"blockHash"`
+}

--- a/client/v2/indexer/lookupBlock.go
+++ b/client/v2/indexer/lookupBlock.go
@@ -8,15 +8,32 @@ import (
 	"github.com/algorand/go-algorand-sdk/client/v2/common/models"
 )
 
+// LookupBlockParams contains all of the query parameters for url serialization.
+type LookupBlockParams struct {
+
+	// HeaderOnly header only flag. When this is set to true, returned block does not
+	// contain the transactions
+	HeaderOnly bool `url:"header-only,omitempty"`
+}
+
 // LookupBlock lookup block.
 type LookupBlock struct {
 	c *Client
 
 	roundNumber uint64
+
+	p LookupBlockParams
+}
+
+// HeaderOnly header only flag. When this is set to true, returned block does not
+// contain the transactions
+func (s *LookupBlock) HeaderOnly(HeaderOnly bool) *LookupBlock {
+	s.p.HeaderOnly = HeaderOnly
+	return s
 }
 
 // Do performs the HTTP request
 func (s *LookupBlock) Do(ctx context.Context, headers ...*common.Header) (response models.Block, err error) {
-	err = s.c.get(ctx, &response, fmt.Sprintf("/v2/blocks/%s", common.EscapeParams(s.roundNumber)...), nil, headers)
+	err = s.c.get(ctx, &response, fmt.Sprintf("/v2/blocks/%s", common.EscapeParams(s.roundNumber)...), s.p, headers)
 	return
 }

--- a/test-harness.sh
+++ b/test-harness.sh
@@ -1,6 +1,46 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
+
+# test-harness.sh setup/start cucumber test environment.
+#
+# Configuration is managed with environment variables, the ones you
+# are most likely to reconfigured are stored in '.test-env'.
+#
+# Variables:
+#   SDK_TESTING_URL     - URL to algorand-sdk-testing, useful for forks.
+#   SDK_TESTING_BRANCH  - branch to checkout, useful for new tests.
+#   SDK_TESTING_HARNESS - local directory that the algorand-sdk-testing repo is cloned into.
+#   VERBOSE_HARNESS     - more output while the script runs.
+#   INSTALL_ONLY        - installs feature files only, useful for unit tests.
+#
+#   WARNING: If set to 1, new features will be LOST when downloading the test harness.
+#   REGARDLESS: modified features are ALWAYS overwritten.
+#   REMOVE_LOCAL_FEATURES - delete all local cucumber feature files before downloading these from github.
+#
+#   WARNING: Be careful when turning on the next variable.
+#   In that case you'll need to provide all variables expected by `algorand-sdk-testing`'s `.env`
+#   OVERWRITE_TESTING_ENVIRONMENT=0
+
+SHUTDOWN=0
+if [ $# -ne 0 ]; then
+  if [ $# -ne 1 ]; then
+    echo "this script accepts a single argument, which must be 'up' or 'down'."
+    exit 1
+  fi
+
+  case $1 in
+    'up')
+      ;; # default.
+    'down')
+      SHUTDOWN=1
+      ;;
+    *)
+      echo "unknown parameter '$1'."
+      echo "this script accepts a single argument, which must be 'up' or 'down'."
+      exit 1
+      ;;
+  esac
+fi
 
 START=$(date "+%s")
 
@@ -23,8 +63,17 @@ if [ -d "$SDK_TESTING_HARNESS" ]; then
   ./scripts/down.sh
   popd
   rm -rf "$SDK_TESTING_HARNESS"
+  if [[ $SHUTDOWN == 1 ]]; then
+    echo "$THIS: network shutdown complete."
+    exit 0
+  fi
 else
   echo "$THIS: directory $SDK_TESTING_HARNESS does not exist - NOOP"
+fi
+
+if [[ $SHUTDOWN == 1 ]]; then
+  echo "$THIS: unable to shutdown network."
+  exit 1
 fi
 
 git clone --depth 1 --single-branch --branch "$SDK_TESTING_BRANCH" "$SDK_TESTING_URL" "$SDK_TESTING_HARNESS"
@@ -51,6 +100,10 @@ if [[ $VERBOSE_HARNESS == 1 ]]; then
 fi
 echo "$THIS: seconds it took to get to end of cloning and copying: $(($(date "+%s") - START))s"
 
+if [[ $INSTALL_ONLY == 1 ]]; then
+  echo "$THIS: configured to install feature files only. Not starting test harness environment."
+  exit 0
+fi
 
 ## Start test harness environment
 pushd "$SDK_TESTING_HARNESS"

--- a/test/algodclientv2_test.go
+++ b/test/algodclientv2_test.go
@@ -50,6 +50,8 @@ func AlgodClientV2Context(s *godog.Suite) {
 	s.Step(`^we make an Account Application Information call against account "([^"]*)" applicationID (\d+)$`, weMakeAnAccountApplicationInformationCallAgainstAccountApplicationID)
 	s.Step(`^we make a GetLightBlockHeaderProof call for round (\d+)$`, weMakeAGetLightBlockHeaderProofCallForRound)
 	s.Step(`^we make a GetStateProof call for round (\d+)$`, weMakeAGetStateProofCallForRound)
+	s.Step(`^we make a GetTransactionProof call for round (\d+) txid "([^"]*)" and hashtype "([^"]*)"$`, weMakeAGetTransactionProofCallForRoundTxidAndHashtype)
+	s.Step(`^we make a Lookup Block Hash call against round (\d+)$`, weMakeALookupBlockHashCallAgainstRound)
 
 	s.BeforeScenario(func(interface{}) {
 		globalErrForExamination = nil
@@ -258,5 +260,23 @@ func weMakeAGetStateProofCallForRound(round int) error {
 		return err
 	}
 	algodClient.GetStateProof(uint64(round)).Do(context.Background())
+	return nil
+}
+
+func weMakeAGetTransactionProofCallForRoundTxidAndHashtype(round int, txid, hashtype string) error {
+	algodClient, err := algod.MakeClient(mockServer.URL, "")
+	if err != nil {
+		return err
+	}
+	algodClient.GetTransactionProof(uint64(round), txid).Hashtype(hashtype).Do(context.Background())
+	return nil
+}
+
+func weMakeALookupBlockHashCallAgainstRound(round int) error {
+	algodClient, err := algod.MakeClient(mockServer.URL, "")
+	if err != nil {
+		return err
+	}
+	algodClient.GetBlockHash(uint64(round)).Do(context.Background())
 	return nil
 }

--- a/test/applications_integration_test.go
+++ b/test/applications_integration_test.go
@@ -452,7 +452,6 @@ func theTransientAccountShouldHave(appCreated string, byteSlices, uints int,
 	return nil
 }
 
-
 func suggestedParamsAlgodV2() error {
 	var err error
 	sugParams, err = aclv2.SuggestedParams().Do(context.Background())

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -94,7 +94,6 @@ func expectErrorStringToContain(contains string) error {
 		"actual error string: %s", contains, globalErrForExamination.Error())
 }
 
-
 func loadResource(filepath string) ([]byte, error) {
 	return ioutil.ReadFile(path.Join("features", "resources", filepath))
 }

--- a/test/indexer_unit_test.go
+++ b/test/indexer_unit_test.go
@@ -53,6 +53,8 @@ func IndexerUnitTestContext(s *godog.Suite) {
 	s.Step(`^we make a Search Accounts call with exclude "([^"]*)"$`, weMakeASearchAccountsCallWithExclude)
 	s.Step(`^we make a Lookup Account by ID call against account "([^"]*)" with exclude "([^"]*)"$`, weMakeALookupAccountByIDCallAgainstAccountWithExclude)
 	s.Step(`^we make a SearchForApplications call with creator "([^"]*)"$`, weMakeASearchForApplicationsCallWithCreator)
+	s.Step(`^we make a Lookup Block call against round (\d+) and header "([^"]*)"$`, weMakeALookupBlockCallAgainstRoundAndHeader)
+
 	s.BeforeScenario(func(interface{}) {
 		globalErrForExamination = nil
 	})
@@ -265,14 +267,14 @@ func weMakeALookupApplicationLogsByIDCallWithApplicationIDLimitMinRoundMaxRoundN
 	return nil
 }
 
-func parseIncludeAll(s string) (bool, error) {
+func parseBool(s string) (bool, error) {
 	if s == "true" {
 		return true, nil
 	}
 	if s == "false" {
 		return false, nil
 	}
-	return false, fmt.Errorf("parseIncludeAll() cannot parse \"%s\"", s)
+	return false, fmt.Errorf("parseBool() cannot parse \"%s\"", s)
 }
 
 func weMakeALookupAccountAssetsCallWithAccountIDAssetIDIncludeAllLimitNext(accountID string, assetID int, includeAll string, limit int, next string) error {
@@ -280,7 +282,7 @@ func weMakeALookupAccountAssetsCallWithAccountIDAssetIDIncludeAllLimitNext(accou
 	if err != nil {
 		return err
 	}
-	includeAllBool, err := parseIncludeAll(includeAll)
+	includeAllBool, err := parseBool(includeAll)
 	if err != nil {
 		return err
 	}
@@ -293,7 +295,7 @@ func weMakeALookupAccountCreatedAssetsCallWithAccountIDAssetIDIncludeAllLimitNex
 	if err != nil {
 		return err
 	}
-	includeAllBool, err := parseIncludeAll(includeAll)
+	includeAllBool, err := parseBool(includeAll)
 	if err != nil {
 		return err
 	}
@@ -306,7 +308,7 @@ func weMakeALookupAccountAppLocalStatesCallWithAccountIDApplicationIDIncludeAllL
 	if err != nil {
 		return err
 	}
-	includeAllBool, err := parseIncludeAll(includeAll)
+	includeAllBool, err := parseBool(includeAll)
 	if err != nil {
 		return err
 	}
@@ -319,7 +321,7 @@ func weMakeALookupAccountCreatedApplicationsCallWithAccountIDApplicationIDInclud
 	if err != nil {
 		return err
 	}
-	includeAllBool, err := parseIncludeAll(includeAll)
+	includeAllBool, err := parseBool(includeAll)
 	if err != nil {
 		return err
 	}
@@ -351,5 +353,20 @@ func weMakeASearchForApplicationsCallWithCreator(creator string) error {
 		return err
 	}
 	indexerClient.SearchForApplications().Creator(creator).Do(context.Background())
+	return nil
+}
+
+func weMakeALookupBlockCallAgainstRoundAndHeader(round int, headerOnly string) error {
+	indexerClient, err := indexer.MakeClient(mockServer.URL, "")
+	if err != nil {
+		return err
+	}
+
+	headerOnlyBool, err := parseBool(headerOnly)
+	if err != nil {
+		return weMakeALookupBlockCallAgainstRound(round)
+	}
+
+	_, globalErrForExamination = indexerClient.LookupBlock(uint64(round)).HeaderOnly(headerOnlyBool).Do(context.Background())
 	return nil
 }

--- a/test/responses_unit_test.go
+++ b/test/responses_unit_test.go
@@ -169,6 +169,9 @@ func weMakeAnyCallTo(client /* algod/indexer */, endpoint string) (err error) {
 		case "GetStateProof":
 			response, err =
 				algodC.GetStateProof(123).Do(context.Background())
+		case "GetBlockHash":
+			response, err =
+				algodC.GetBlockHash(123).Do(context.Background())
 		case "any":
 			// This is an error case
 			// pickup the error as the response

--- a/test/unit.tags
+++ b/test/unit.tags
@@ -1,6 +1,7 @@
 @unit.abijson
 @unit.abijson.byname
 @unit.algod
+@unit.blocksummary
 @unit.algod.ledger_refactoring
 @unit.applications
 @unit.atomic_transaction_composer
@@ -21,6 +22,7 @@
 @unit.responses.messagepack.231
 @unit.responses.participationupdates
 @unit.responses.unlimited_assets
+@unit.responses.blocksummary
 @unit.sourcemap
 @unit.stateproof.paths
 @unit.stateproof.responses


### PR DESCRIPTION
![GitHub Logo](https://raw.githubusercontent.com/algorand/go-algorand/master/release/release-banner.jpg)

# go-algorand-sdk release v1.22.0

## Enhancements
* REST API: Add algod block hash endpoint, add indexer block header-only param. ([#421](https://github.com/algorand/go-algorand-sdk/pull/421))
## Protocol Upgrade
This release does not contain a protocol upgrade.

## Additional Resources
* [Algorand Forum](https://forum.algorand.org)
* [Developer Documentation](https://developer.algorand.org)
