### PR TITLE
Regenerate sources from upstream AVM branches

### DIFF
--- a/client/v2/algod/getApplicationBoxes.go
+++ b/client/v2/algod/getApplicationBoxes.go
@@ -16,8 +16,9 @@ type GetApplicationBoxesParams struct {
 	Max uint64 `url:"max,omitempty"`
 }
 
-// GetApplicationBoxes given an application ID, it returns the box names of that
-// application. No particular ordering is guaranteed.
+// GetApplicationBoxes given an application ID, return all Box names. No particular
+// ordering is guaranteed. Request fails when client or server-side configured
+// limits prevent returning all Box names.
 type GetApplicationBoxes struct {
 	c *Client
 


### PR DESCRIPTION
Regenerates sources from upstream go-algorand + indexer AVM branches and brings in `develop` for the final time prior to merging the parent branch.