### PR TITLE
Tests: Support for new cucumber app call txn decoding test

### DIFF
--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="master"
+SDK_TESTING_BRANCH="app-txn-decode"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="app-txn-decode"
+SDK_TESTING_BRANCH="master"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/test/applications_integration_test.go
+++ b/test/applications_integration_test.go
@@ -328,6 +328,10 @@ func parseBoxes(boxesStr string) (staticBoxes []types.AppBoxReference, err error
 			}
 		}
 
+		if len(nameBytes) == 0 {
+			nameBytes = nil
+		}
+
 		staticBoxes = append(staticBoxes,
 			types.AppBoxReference{
 				AppID: appID,

--- a/test/steps_test.go
+++ b/test/steps_test.go
@@ -2504,7 +2504,7 @@ func theDecodedTransactionShouldEqualTheOriginal() error {
 		return err
 	}
 
-	// This test isn't perfect as it's sensative to non-meaningfil changes (e.g. nil slice vs 0
+	// This test isn't perfect as it's sensitive to non-meaningful changes (e.g. nil slice vs 0
 	// length slice), but it's good enough for now. We may want a Transaction.Equals method in the
 	// future.
 	if !reflect.DeepEqual(tx, decodedTx.Txn) {

--- a/test/steps_test.go
+++ b/test/steps_test.go
@@ -377,7 +377,6 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^I build a payment transaction with sender "([^"]*)", receiver "([^"]*)", amount (\d+), close remainder to "([^"]*)"$`, iBuildAPaymentTransactionWithSenderReceiverAmountCloseRemainderTo)
 	s.Step(`^I create a transaction with signer with the current transaction\.$`, iCreateATransactionWithSignerWithTheCurrentTransaction)
 	s.Step(`^I append the current transaction with signer to the method arguments array\.$`, iAppendTheCurrentTransactionWithSignerToTheMethodArgumentsArray)
-	s.Step(`^the decoded transaction should equal the original$`, theDecodedTransactionShouldEqualTheOriginal)
 	s.Step(`^a dryrun response file "([^"]*)" and a transaction at index "([^"]*)"$`, aDryrunResponseFileAndATransactionAtIndex)
 	s.Step(`^calling app trace produces "([^"]*)"$`, callingAppTraceProduces)
 	s.Step(`^I append to my Method objects list in the case of a non-empty signature "([^"]*)"$`, iAppendToMyMethodObjectsListInTheCaseOfANonemptySignature)
@@ -2505,7 +2504,13 @@ func theDecodedTransactionShouldEqualTheOriginal() error {
 		return err
 	}
 
-	// direct tx equality checking isn't fully implemented in go-sdk so this test is incomplete
+	// This test isn't perfect as it's sensative to non-meaningfil changes (e.g. nil slice vs 0
+	// length slice), but it's good enough for now. We may want a Transaction.Equals method in the
+	// future.
+	if !reflect.DeepEqual(tx, decodedTx.Txn) {
+		return fmt.Errorf("Transactions unequal: %#v != %#v", tx, decodedTx.Txn)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR adds support for https://github.com/algorand/algorand-sdk-testing/pull/248

Note: the code exported by this library does not suffer from the same bug as https://github.com/algorand/js-algorand-sdk/issues/688, but some changes were needed to get the test to pass properly.

I don't believe this PR necessitates a patch release.