### PR TITLE
Refactoring: Move old transaction dependencies to future.transaction

### DIFF
--- a/future/transaction.go
+++ b/future/transaction.go
@@ -14,6 +14,9 @@ import (
 // MinTxnFee is v5 consensus params, in microAlgos
 const MinTxnFee = transaction.MinTxnFee
 
+// NumOfAdditionalBytesAfterSigning is the number of bytes added to a txn after signing it
+const NumOfAdditionalBytesAfterSigning = 75
+
 func setFee(tx types.Transaction, params types.SuggestedParams) (types.Transaction, error) {
 	if !params.FlatFee {
 		eSize, err := EstimateSize(tx)
@@ -1302,7 +1305,6 @@ func AssignGroupID(txns []types.Transaction, account string) (result []types.Tra
 
 // EstimateSize returns the estimated length of the encoded transaction
 func EstimateSize(txn types.Transaction) (uint64, error) {
-	const NumOfAdditionalBytesAfterSigning = 75
 	return uint64(len(msgpack.Encode(txn))) + NumOfAdditionalBytesAfterSigning, nil
 }
 

--- a/future/transaction_test.go
+++ b/future/transaction_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/algorand/go-algorand-sdk/crypto"
 	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
 	"github.com/algorand/go-algorand-sdk/mnemonic"
-	"github.com/algorand/go-algorand-sdk/transaction"
 	"github.com/algorand/go-algorand-sdk/types"
 	"github.com/stretchr/testify/require"
 )
@@ -841,15 +840,15 @@ func TestComputeGroupID(t *testing.T) {
 	require.Equal(t, byteFromBase64(goldenTxg), txg)
 
 	// check transaction.AssignGroupID, do not validate correctness of Group field calculation
-	result, err := transaction.AssignGroupID([]types.Transaction{tx1, tx2}, "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4")
+	result, err := AssignGroupID([]types.Transaction{tx1, tx2}, "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4")
 	require.NoError(t, err)
 	require.Equal(t, 0, len(result))
 
-	result, err = transaction.AssignGroupID([]types.Transaction{tx1, tx2}, address)
+	result, err = AssignGroupID([]types.Transaction{tx1, tx2}, address)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(result))
 
-	result, err = transaction.AssignGroupID([]types.Transaction{tx1, tx2}, "")
+	result, err = AssignGroupID([]types.Transaction{tx1, tx2}, "")
 	require.NoError(t, err)
 	require.Equal(t, 2, len(result))
 }

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+
 	"github.com/algorand/go-algorand-sdk/crypto"
 	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
 	"github.com/algorand/go-algorand-sdk/types"


### PR DESCRIPTION
This PR moves some dependencies in the old `transaction` into `future.transaction` to prepare for the new SDK version.

This is a part of #396 .