### PR TITLE
v2: Update model for dryrun to delete deprecated cost field

### DIFF
--- a/client/v2/common/models/dryrun_txn_result.go
+++ b/client/v2/common/models/dryrun_txn_result.go
@@ -15,10 +15,6 @@ type DryrunTxnResult struct {
 	// BudgetConsumed budget consumed during execution of app call transaction.
 	BudgetConsumed uint64 `json:"budget-consumed,omitempty"`
 
-	// Cost net cost of app execution. Field is DEPRECATED and is subject for removal.
-	// Instead, use `budget-added` and `budget-consumed.
-	Cost uint64 `json:"cost,omitempty"`
-
 	// Disassembly disassembled program line by line.
 	Disassembly []string `json:"disassembly"`
 


### PR DESCRIPTION
Updates dryrun model to delete cost field. Cherry-picks just this change from generated code.

Currently points to the v2 breaking change feature branch.

Part of https://github.com/algorand/algorand-sdk-testing/issues/201