### PR TITLE
tests: Check for non-empty expected err string

### DIFF
--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="revert-sandbox"
+SDK_TESTING_BRANCH="master"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="master"
+SDK_TESTING_BRANCH="revert-sandbox"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/test/applications_integration_test.go
+++ b/test/applications_integration_test.go
@@ -786,7 +786,9 @@ func theContentsOfTheBoxWithNameShouldBeIfThereIsAnErrorItIs(fromClient, encoded
 		err = fmt.Errorf("expecting algod or indexer, got " + fromClient)
 	}
 	if err != nil {
-		if strings.Contains(err.Error(), errStr) {
+		// If the expected error string is not empty, check if it is a substring of the actual error string.
+		// Note that if the expected error string is empty, then the second condition will always return true.
+		if errStr != "" && strings.Contains(err.Error(), errStr) {
 			return nil
 		}
 		return err

--- a/test/applications_integration_test.go
+++ b/test/applications_integration_test.go
@@ -785,15 +785,10 @@ func theContentsOfTheBoxWithNameShouldBeIfThereIsAnErrorItIs(fromClient, encoded
 	} else {
 		err = fmt.Errorf("expecting algod or indexer, got " + fromClient)
 	}
-<<<<<<< HEAD
 	if err != nil {
 		// If the expected error string is not empty, check if it is a substring of the actual error string.
 		// Note that if the expected error string is empty, then the second condition will always return true.
 		if len(errStr) != 0 && strings.Contains(err.Error(), errStr) {
-=======
-	if err != nil && len(errStr) != 0 {
-		if strings.Contains(err.Error(), errStr) {
->>>>>>> 2d2fb97fd783d3ca5b727270679909b694765c8e
 			return nil
 		}
 		return err

--- a/test/applications_integration_test.go
+++ b/test/applications_integration_test.go
@@ -788,7 +788,7 @@ func theContentsOfTheBoxWithNameShouldBeIfThereIsAnErrorItIs(fromClient, encoded
 	if err != nil {
 		// If the expected error string is not empty, check if it is a substring of the actual error string.
 		// Note that if the expected error string is empty, then the second condition will always return true.
-		if errStr != "" && strings.Contains(err.Error(), errStr) {
+		if len(errStr) != 0 && strings.Contains(err.Error(), errStr) {
 			return nil
 		}
 		return err

--- a/test/applications_integration_test.go
+++ b/test/applications_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -792,6 +793,9 @@ func theContentsOfTheBoxWithNameShouldBeIfThereIsAnErrorItIs(fromClient, encoded
 			return nil
 		}
 		return err
+	}
+	if len(errStr) != 0 {
+		return errors.New("expected an error but none was reported")
 	}
 
 	b64Value := base64.StdEncoding.EncodeToString(box.Value)


### PR DESCRIPTION
This PR changes a test check so that if the expected error string is empty, it fails the check if there is an actual error.

Currently, checking whether an empty error string is a substring of a non-empty actual error string will always return true, which is not intended behavior. 