### PR TITLE
generator: Delete some stale generated files

### DIFF
--- a/client/v2/common/models/catchpoint_abort_response.go
+++ b/client/v2/common/models/catchpoint_abort_response.go
@@ -1,7 +1,0 @@
-package models
-
-// CatchpointAbortResponse
-type CatchpointAbortResponse struct {
-	// CatchupMessage catchup abort response string
-	CatchupMessage string `json:"catchup-message"`
-}

--- a/client/v2/common/models/catchpoint_start_response.go
+++ b/client/v2/common/models/catchpoint_start_response.go
@@ -1,7 +1,0 @@
-package models
-
-// CatchpointStartResponse
-type CatchpointStartResponse struct {
-	// CatchupMessage catchup start response string
-	CatchupMessage string `json:"catchup-message"`
-}


### PR DESCRIPTION
Reflects changes from https://github.com/algorand/generator/pull/47

We delete previously generated files that had the `private` tag on them. Currently targets `develop`.