### PR TITLE
v2: Restore MakeLogicSigAccountEscrowChecked

### DIFF
--- a/crypto/account.go
+++ b/crypto/account.go
@@ -187,9 +187,9 @@ type LogicSigAccount struct {
 	SigningKey ed25519.PublicKey `codec:"sigkey"`
 }
 
-// MakeLogicSigAccountEscrow creates a new escrow LogicSigAccount.
+// MakeLogicSigAccountEscrowChecked creates a new escrow LogicSigAccount.
 // The address of this account will be a hash of its program.
-func MakeLogicSigAccountEscrow(program []byte, args [][]byte) (LogicSigAccount, error) {
+func MakeLogicSigAccountEscrowChecked(program []byte, args [][]byte) (LogicSigAccount, error) {
 	lsig, err := makeLogicSig(program, args, nil, MultisigAccount{})
 	if err != nil {
 		return LogicSigAccount{}, err

--- a/crypto/account_test.go
+++ b/crypto/account_test.go
@@ -167,7 +167,7 @@ func TestMakeLogicSigAccount(t *testing.T) {
 	}
 
 	t.Run("Escrow", func(t *testing.T) {
-		lsigAccount, err := MakeLogicSigAccountEscrow(program, args)
+		lsigAccount, err := MakeLogicSigAccountEscrowChecked(program, args)
 		require.NoError(t, err)
 
 		require.Equal(t, program, lsigAccount.Lsig.Logic)
@@ -351,7 +351,7 @@ func TestLogicSigAccount_Address(t *testing.T) {
 	}
 
 	t.Run("no sig", func(t *testing.T) {
-		lsigAccount, err := MakeLogicSigAccountEscrow(program, args)
+		lsigAccount, err := MakeLogicSigAccountEscrowChecked(program, args)
 		require.NoError(t, err)
 
 		expectedAddr, err := types.DecodeAddress("6Z3C3LDVWGMX23BMSYMANACQOSINPFIRF77H7N3AWJZYV6OH6GWTJKVMXY")

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -618,7 +618,7 @@ func TestSignLogicSigAccountTransaction(t *testing.T) {
 	}
 
 	t.Run("no sig", func(t *testing.T) {
-		lsigAccount, err := MakeLogicSigAccountEscrow(program, args)
+		lsigAccount, err := MakeLogicSigAccountEscrowChecked(program, args)
 		require.NoError(t, err)
 
 		programAddr, err := types.DecodeAddress("6Z3C3LDVWGMX23BMSYMANACQOSINPFIRF77H7N3AWJZYV6OH6GWTJKVMXY")

--- a/test/steps_test.go
+++ b/test/steps_test.go
@@ -2543,7 +2543,7 @@ func takeB64encodedBytes(b64encodedBytes string) error {
 }
 
 func heuristicCheckOverBytes() error {
-	_, sanityCheckError = crypto.MakeLogicSigAccountEscrow(seeminglyProgram, nil)
+	_, sanityCheckError = crypto.MakeLogicSigAccountEscrowChecked(seeminglyProgram, nil)
 	return nil
 }
 


### PR DESCRIPTION
Partially reverts https://github.com/algorand/go-algorand-sdk/pull/450 by restoring `MakeLogicSigAccountEscrowChecked`.

#450 did the following:
* Remove deprecated function called `MakeLogicSigAccountEscrow`.
* Rename non-deprecated function from `MakeLogicSigAccountEscrowChecked` to `MakeLogicSigAccountEscrow`.

Upon closer inspection, we've agreed the non-deprecated rename should _not_ be changed in v2.0.0.