### PR TITLE
bugfix: Fix wrong response error type.

### DIFF
--- a/client/v2/common/common.go
+++ b/client/v2/common/common.go
@@ -181,7 +181,7 @@ func (client *Client) submitForm(ctx context.Context, response interface{}, path
 	// The caller wants a string
 	if strResponse, ok := response.(*string); ok {
 		*strResponse = string(bodyBytes)
-		return err
+		return responseErr
 	}
 
 	// Attempt to unmarshal a response regardless of whether or not there was an error.


### PR DESCRIPTION
I noticed an endpoint return a "Not Found" message and a nil error. We were returning the wrong error here.