### PR TITLE
tests: Add disassembly test for Go SDK

### DIFF
--- a/test/integration.tags
+++ b/test/integration.tags
@@ -6,6 +6,7 @@
 @auction
 @c2c
 @compile
+@compile.disassemble
 @compile.sourcemap
 @dryrun
 @kmd


### PR DESCRIPTION
Adds the disassembly test introduced in this PR: https://github.com/algorand/algorand-sdk-testing/pull/251

The disassembly endpoint was introduced in this PR: https://github.com/algorand/go-algorand-sdk/pull/436