### PR TITLE
enhancement: address and blockhash encoding

### DIFF
--- a/types/address.go
+++ b/types/address.go
@@ -34,10 +34,10 @@ func (a Address) IsZero() bool {
 	return a == ZeroAddress
 }
 
-// MarshalText returns the address string as an array of bytes
-func (addr Address) MarshalText() ([]byte, error) {
-	return []byte(addr.String()), nil
-}
+//// MarshalText returns the address string as an array of bytes
+//func (addr Address) MarshalText() ([]byte, error) {
+//	return []byte(addr.String()), nil
+//}
 
 // UnmarshalText initializes the Address from an array of bytes.
 func (addr *Address) UnmarshalText(text []byte) error {

--- a/types/address.go
+++ b/types/address.go
@@ -34,6 +34,21 @@ func (a Address) IsZero() bool {
 	return a == ZeroAddress
 }
 
+// MarshalText returns the address string as an array of bytes
+func (addr Address) MarshalText() ([]byte, error) {
+	return []byte(addr.String()), nil
+}
+
+// UnmarshalText initializes the Address from an array of bytes.
+func (addr *Address) UnmarshalText(text []byte) error {
+	address, err := DecodeAddress(string(text))
+	if err == nil {
+		*addr = address
+		return nil
+	}
+	return err
+}
+
 // DecodeAddress turns a checksum address string into an Address object. It
 // checks that the checksum is correct, and returns an error if it's not.
 func DecodeAddress(addr string) (a Address, err error) {

--- a/types/address.go
+++ b/types/address.go
@@ -34,10 +34,10 @@ func (a Address) IsZero() bool {
 	return a == ZeroAddress
 }
 
-//// MarshalText returns the address string as an array of bytes
-//func (addr Address) MarshalText() ([]byte, error) {
-//	return []byte(addr.String()), nil
-//}
+// MarshalText returns the address string as an array of bytes
+func (addr Address) MarshalText() ([]byte, error) {
+	return []byte(addr.String()), nil
+}
 
 // UnmarshalText initializes the Address from an array of bytes.
 func (addr *Address) UnmarshalText(text []byte) error {

--- a/types/basics.go
+++ b/types/basics.go
@@ -103,11 +103,6 @@ func (block *Block) FromBase64String(b64string string) error {
 	return nil
 }
 
-// String returns the digest in a human-readable Base32 string
-func (d Digest) String() string {
-	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(d[:])
-}
-
 // DigestFromString converts a string to a Digest
 func DigestFromString(str string) (d Digest, err error) {
 	decoded, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(str)
@@ -120,18 +115,4 @@ func DigestFromString(str string) (d Digest, err error) {
 	}
 	copy(d[:], decoded[:])
 	return d, err
-}
-
-func (d Digest) MarshalText() ([]byte, error) {
-	return []byte(d.String()), nil
-}
-
-// UnmarshalText initializes the Address from an array of bytes.
-func (d *Digest) UnmarshalText(text []byte) error {
-	digest, err := DigestFromString(string(text))
-	if err == nil {
-		*d = digest
-		return nil
-	}
-	return err
 }

--- a/types/basics.go
+++ b/types/basics.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/base32"
 	"encoding/base64"
 	"math"
 
@@ -98,4 +99,9 @@ func (block *Block) FromBase64String(b64string string) error {
 		return err
 	}
 	return nil
+}
+
+// String returns the digest in a human-readable Base32 string
+func (d Digest) String() string {
+	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(d[:])
 }

--- a/types/basics.go
+++ b/types/basics.go
@@ -3,6 +3,8 @@ package types
 import (
 	"encoding/base32"
 	"encoding/base64"
+	"errors"
+	"fmt"
 	"math"
 
 	"github.com/algorand/go-algorand-sdk/v2/encoding/msgpack"
@@ -104,4 +106,32 @@ func (block *Block) FromBase64String(b64string string) error {
 // String returns the digest in a human-readable Base32 string
 func (d Digest) String() string {
 	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(d[:])
+}
+
+// DigestFromString converts a string to a Digest
+func DigestFromString(str string) (d Digest, err error) {
+	decoded, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(str)
+	if err != nil {
+		return d, err
+	}
+	if len(decoded) != len(d) {
+		msg := fmt.Sprintf(`Attempted to decode a string which was not a Digest: "%v"`, str)
+		return d, errors.New(msg)
+	}
+	copy(d[:], decoded[:])
+	return d, err
+}
+
+//func (d Digest) MarshalText() ([]byte, error) {
+//	return []byte(d.String()), nil
+//}
+
+// UnmarshalText initializes the Address from an array of bytes.
+func (d *Digest) UnmarshalText(text []byte) error {
+	digest, err := DigestFromString(string(text))
+	if err == nil {
+		*d = digest
+		return nil
+	}
+	return err
 }

--- a/types/basics.go
+++ b/types/basics.go
@@ -122,9 +122,9 @@ func DigestFromString(str string) (d Digest, err error) {
 	return d, err
 }
 
-//func (d Digest) MarshalText() ([]byte, error) {
-//	return []byte(d.String()), nil
-//}
+func (d Digest) MarshalText() ([]byte, error) {
+	return []byte(d.String()), nil
+}
 
 // UnmarshalText initializes the Address from an array of bytes.
 func (d *Digest) UnmarshalText(text []byte) error {

--- a/types/blockhash.go
+++ b/types/blockhash.go
@@ -1,0 +1,26 @@
+package types
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+func (b BlockHash) String() string {
+	return fmt.Sprintf("blk-%v", Digest(b))
+}
+
+// MarshalText returns the BlockHash string as an array of bytes
+func (b BlockHash) MarshalText() ([]byte, error) {
+	return []byte(b.String()), nil
+}
+
+// UnmarshalText initializes the BlockHash from an array of bytes.
+func (b *BlockHash) UnmarshalText(text []byte) error {
+	if len(text) < 4 || !bytes.Equal(text[0:4], []byte("blk-")) {
+		return errors.New("unrecognized blockhash format")
+	}
+	d, err := DigestFromString(string(text[4:]))
+	*b = BlockHash(d)
+	return err
+}


### PR DESCRIPTION
This PR implements marshal/unmarshal interface for Address and Blockhash data types so bookkeeping.Block can be deserialized to sdk.Block. This change is need for Indexer.  It gets block of type bookkeeping.Block from algod but it needs sdk.Block type. 