### PR TITLE
marshaling: Lenient Address and BlockHash go-codec unmarshalers.

### DIFF
--- a/types/address.go
+++ b/types/address.go
@@ -34,10 +34,10 @@ func (a Address) IsZero() bool {
 	return a == ZeroAddress
 }
 
-// MarshalText returns the address string as an array of bytes
-func (addr Address) MarshalText() ([]byte, error) {
-	return []byte(addr.String()), nil
-}
+//// MarshalText returns the address string as an array of bytes
+//func (addr Address) MarshalText() ([]byte, error) {
+//	return []byte(addr.String()), nil
+//}
 
 // UnmarshalText initializes the Address from an array of bytes.
 func (addr *Address) UnmarshalText(text []byte) error {

--- a/types/address.go
+++ b/types/address.go
@@ -34,6 +34,21 @@ func (a Address) IsZero() bool {
 	return a == ZeroAddress
 }
 
+// MarshalText returns the address string as an array of bytes
+func (addr Address) MarshalText() ([]byte, error) {
+	return []byte(addr.String()), nil
+}
+
+// UnmarshalText initializes the Address from an array of bytes.
+func (addr *Address) UnmarshalText(text []byte) error {
+	address, err := DecodeAddress(string(text))
+	if err == nil {
+		*addr = address
+		return nil
+	}
+	return err
+}
+
 // DecodeAddress turns a checksum address string into an Address object. It
 // checks that the checksum is correct, and returns an error if it's not.
 func DecodeAddress(addr string) (a Address, err error) {

--- a/types/address.go
+++ b/types/address.go
@@ -34,10 +34,10 @@ func (a Address) IsZero() bool {
 	return a == ZeroAddress
 }
 
-//// MarshalText returns the address string as an array of bytes
-//func (addr Address) MarshalText() ([]byte, error) {
-//	return []byte(addr.String()), nil
-//}
+// MarshalText returns the address string as an array of bytes
+func (addr Address) MarshalText() ([]byte, error) {
+	return []byte(addr.String()), nil
+}
 
 // UnmarshalText initializes the Address from an array of bytes.
 func (addr *Address) UnmarshalText(text []byte) error {

--- a/types/address_test.go
+++ b/types/address_test.go
@@ -2,9 +2,12 @@ package types
 
 import (
 	"crypto/rand"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	json2 "github.com/algorand/go-algorand-sdk/v2/encoding/json"
 )
 
 func randomBytes(s []byte) {
@@ -36,4 +39,57 @@ func TestGoldenValues(t *testing.T) {
 		a[i] = byte(0xFF)
 	}
 	require.Equal(t, golden, a.String())
+}
+
+func TestUnmarshalAddress(t *testing.T) {
+	testcases := []struct {
+		name   string
+		input  string
+		str    string
+		output string
+		err    string
+	}{
+		{
+			name:   "B32+Checksum",
+			input:  "7HJBGRIWI7GDL42SOJNIAZ7LJ7EBEGKGE5S52QZXAWDXOHDKMDFR6AUXDE",
+			str:    "7HJBGRIWI7GDL42SOJNIAZ7LJ7EBEGKGE5S52QZXAWDXOHDKMDFR6AUXDE",
+			output: "+dITRRZHzDXzUnJagGfrT8gSGUYnZd1DNwWHdxxqYMs=",
+		}, {
+			name:   "B64",
+			input:  "+dITRRZHzDXzUnJagGfrT8gSGUYnZd1DNwWHdxxqYMs=",
+			str:    "7HJBGRIWI7GDL42SOJNIAZ7LJ7EBEGKGE5S52QZXAWDXOHDKMDFR6AUXDE",
+			output: "+dITRRZHzDXzUnJagGfrT8gSGUYnZd1DNwWHdxxqYMs=",
+		}, {
+			name:  "B64-err-length",
+			input: "AAE=",
+			err:   "decoded address is the wrong length",
+		}, {
+			name:  "B64-err-illegal",
+			input: "bogus",
+			err:   "illegal base64 data at input byte 4",
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// wrap in quotes so that it is valid JSON
+			data := []byte(fmt.Sprintf("\"%s\"", tc.input))
+
+			var addr Address
+			err := json2.Decode(data, &addr)
+			if tc.err != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.str, addr.String())
+			actual, err := addr.MarshalText()
+			require.NoError(t, err)
+			require.Equal(t, tc.output, string(actual))
+			fmt.Println(string(actual))
+		})
+	}
 }

--- a/types/basics.go
+++ b/types/basics.go
@@ -103,11 +103,6 @@ func (block *Block) FromBase64String(b64string string) error {
 	return nil
 }
 
-// String returns the digest in a human-readable Base32 string
-func (d Digest) String() string {
-	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(d[:])
-}
-
 // DigestFromString converts a string to a Digest
 func DigestFromString(str string) (d Digest, err error) {
 	decoded, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(str)
@@ -120,18 +115,4 @@ func DigestFromString(str string) (d Digest, err error) {
 	}
 	copy(d[:], decoded[:])
 	return d, err
-}
-
-func (d Digest) MarshalText() ([]byte, error) {
-	return []byte(d.String()), nil
-}
-
-// UnmarshalText initializes the Address from an array of bytes.
-func (d *Digest) UnmarshalText(text []byte) error {
-	digest, err := DigestFromString(string(text))
-	if err == nil {
-		*d = digest
-		return nil
-	}
-	return err
 }

--- a/types/basics.go
+++ b/types/basics.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/base32"
 	"encoding/base64"
 	"math"
 
@@ -98,4 +99,9 @@ func (block *Block) FromBase64String(b64string string) error {
 		return err
 	}
 	return nil
+}
+
+// String returns the digest in a human-readable Base32 string
+func (d Digest) String() string {
+	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(d[:])
 }

--- a/types/basics.go
+++ b/types/basics.go
@@ -3,6 +3,8 @@ package types
 import (
 	"encoding/base32"
 	"encoding/base64"
+	"errors"
+	"fmt"
 	"math"
 
 	"github.com/algorand/go-algorand-sdk/v2/encoding/msgpack"
@@ -104,4 +106,32 @@ func (block *Block) FromBase64String(b64string string) error {
 // String returns the digest in a human-readable Base32 string
 func (d Digest) String() string {
 	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(d[:])
+}
+
+// DigestFromString converts a string to a Digest
+func DigestFromString(str string) (d Digest, err error) {
+	decoded, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(str)
+	if err != nil {
+		return d, err
+	}
+	if len(decoded) != len(d) {
+		msg := fmt.Sprintf(`Attempted to decode a string which was not a Digest: "%v"`, str)
+		return d, errors.New(msg)
+	}
+	copy(d[:], decoded[:])
+	return d, err
+}
+
+//func (d Digest) MarshalText() ([]byte, error) {
+//	return []byte(d.String()), nil
+//}
+
+// UnmarshalText initializes the Address from an array of bytes.
+func (d *Digest) UnmarshalText(text []byte) error {
+	digest, err := DigestFromString(string(text))
+	if err == nil {
+		*d = digest
+		return nil
+	}
+	return err
 }

--- a/types/basics.go
+++ b/types/basics.go
@@ -122,9 +122,9 @@ func DigestFromString(str string) (d Digest, err error) {
 	return d, err
 }
 
-//func (d Digest) MarshalText() ([]byte, error) {
-//	return []byte(d.String()), nil
-//}
+func (d Digest) MarshalText() ([]byte, error) {
+	return []byte(d.String()), nil
+}
 
 // UnmarshalText initializes the Address from an array of bytes.
 func (d *Digest) UnmarshalText(text []byte) error {

--- a/types/blockhash.go
+++ b/types/blockhash.go
@@ -1,0 +1,26 @@
+package types
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+func (b BlockHash) String() string {
+	return fmt.Sprintf("blk-%v", Digest(b))
+}
+
+// MarshalText returns the BlockHash string as an array of bytes
+func (b BlockHash) MarshalText() ([]byte, error) {
+	return []byte(b.String()), nil
+}
+
+// UnmarshalText initializes the BlockHash from an array of bytes.
+func (b *BlockHash) UnmarshalText(text []byte) error {
+	if len(text) < 4 || !bytes.Equal(text[0:4], []byte("blk-")) {
+		return errors.New("unrecognized blockhash format")
+	}
+	d, err := DigestFromString(string(text[4:]))
+	*b = BlockHash(d)
+	return err
+}

--- a/types/blockhash_test.go
+++ b/types/blockhash_test.go
@@ -1,0 +1,62 @@
+package types
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	json2 "github.com/algorand/go-algorand-sdk/v2/encoding/json"
+)
+
+func TestUnmarshalBlockHash(t *testing.T) {
+	testcases := []struct {
+		name      string
+		input     string
+		outputB64 string
+		err       string
+	}{
+		{
+			name:      "blk-B32",
+			input:     "blk-PEMLJXJYPLIFJ7DGVGTSEGUHUFR3M6Y67UZW3AC4LLNLF26XIXQA",
+			outputB64: "eRi03Th60FT8ZqmnIhqHoWO2ex79M22AXFrasuvXReA=",
+		}, {
+			name:      "B32",
+			input:     "PEMLJXJYPLIFJ7DGVGTSEGUHUFR3M6Y67UZW3AC4LLNLF26XIXQA",
+			outputB64: "eRi03Th60FT8ZqmnIhqHoWO2ex79M22AXFrasuvXReA=",
+		}, {
+			name:      "B64",
+			input:     "eRi03Th60FT8ZqmnIhqHoWO2ex79M22AXFrasuvXReA=",
+			outputB64: "eRi03Th60FT8ZqmnIhqHoWO2ex79M22AXFrasuvXReA=",
+		}, {
+			name:  "B64-err-length",
+			input: "AAE=",
+			err:   "decoded block hash is the wrong length",
+		}, {
+			name:  "B64-err-illegal",
+			input: "bogus",
+			err:   "illegal base64 data at input byte 4",
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// wrap in quotes so that it is valid JSON
+			data := []byte(fmt.Sprintf("\"%s\"", tc.input))
+
+			var hash BlockHash
+			err := json2.Decode(data, &hash)
+			if tc.err != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.err)
+				return
+			}
+			require.NoError(t, err)
+			actual, err := hash.MarshalText()
+			require.NoError(t, err)
+			require.Equal(t, tc.outputB64, string(actual))
+		})
+	}
+}

--- a/types/errors.go
+++ b/types/errors.go
@@ -7,3 +7,4 @@ import (
 var errWrongAddressByteLen = fmt.Errorf("encoding address is the wrong length, should be %d bytes", hashLenBytes)
 var errWrongAddressLen = fmt.Errorf("decoded address is the wrong length, should be %d bytes", hashLenBytes+checksumLenBytes)
 var errWrongChecksum = fmt.Errorf("address checksum is incorrect, did you copy the address correctly?")
+var errWrongBlockHashLen = fmt.Errorf("decoded block hash is the wrong length, should be %d bytes", Sha512_256Size)


### PR DESCRIPTION
Add custom marshaling and unmarshaling to Address and BlockHash to account for differences between how the SDK marshals a block and how go-algorand marshals a block.

With these changes the SDK should be able to unmarshal data regardless of which flavor of marshaling was used.