### PR TITLE
bug: Fix extractError parsing

### DIFF
--- a/client/v2/common/common.go
+++ b/client/v2/common/common.go
@@ -73,7 +73,7 @@ type InternalError error
 // If so, it returns the error.
 // Otherwise, it returns nil.
 func extractError(code int, errorBuf []byte) error {
-	if code == 200 {
+	if code >= 200 && code < 300 {
 		return nil
 	}
 

--- a/client/v2/common/common_test.go
+++ b/client/v2/common/common_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,6 +10,27 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestExtractError(t *testing.T) {
+	testcases := []struct {
+		name string
+		code int
+		err  error
+	}{
+		{name: "400", code: 400, err: BadRequest(fmt.Errorf("HTTP 400: "))},
+		{name: "401", code: 401, err: InvalidToken(fmt.Errorf("HTTP 401: "))},
+		{name: "404", code: 404, err: NotFound(fmt.Errorf("HTTP 404: "))},
+		{name: "500", code: 500, err: InternalError(fmt.Errorf("HTTP 500: "))},
+		{name: "200", code: 200, err: nil},
+		{name: "201", code: 201, err: nil},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.err, extractError(tc.code, []byte{}))
+		})
+	}
+}
 
 func TestClient_Verbs(t *testing.T) {
 	path := "/some/path"


### PR DESCRIPTION
Current extract error status parsing treats only a `200` response as success whereas it should be any status code in the 200s.

Corrected the conditional responsible for this and added unit tests.