### PR TITLE
Add MakeClientWithTransport client override that allows the user to pass a custom http transport

### DIFF
--- a/client/v2/algod/algod.go
+++ b/client/v2/algod/algod.go
@@ -2,6 +2,7 @@ package algod
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/algorand/go-algorand-sdk/v2/client/v2/common"
 	"github.com/algorand/go-algorand-sdk/v2/client/v2/common/models"
@@ -50,6 +51,14 @@ func MakeClient(address string, apiToken string) (c *Client, err error) {
 func MakeClientWithHeaders(address string, apiToken string, headers []*common.Header) (c *Client, err error) {
 	commonClientWithHeaders, err := common.MakeClientWithHeaders(address, authHeader, apiToken, headers)
 	c = (*Client)(commonClientWithHeaders)
+	return
+}
+
+// MakeClientWithTransport is the factory for constructing a Client for a given endpoint with a
+// custom HTTP Transport as well as optional additional user defined headers.
+func MakeClientWithTransport(address string, apiToken string, headers []*common.Header, transport http.RoundTripper) (c *Client, err error) {
+	commonClientWithTransport, err := common.MakeClientWithTransport(address, authHeader, apiToken, headers, transport)
+	c = (*Client)(commonClientWithTransport)
 	return
 }
 

--- a/client/v2/common/common.go
+++ b/client/v2/common/common.go
@@ -3,7 +3,6 @@ package common
 import (
 	"bytes"
 	"context"
-
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -35,6 +34,7 @@ type Client struct {
 	apiHeader string
 	apiToken  string
 	headers   []*Header
+	transport http.RoundTripper
 }
 
 // MakeClient is the factory for constructing a Client for a given endpoint.
@@ -60,6 +60,19 @@ func MakeClientWithHeaders(address string, apiHeader, apiToken string, headers [
 	}
 
 	c.headers = append(c.headers, headers...)
+
+	return
+}
+
+// MakeClientWithTransport is the factory for constructing a Client for a given endpoint with a
+// custom HTTP Transport as well as optional additional user defined headers.
+func MakeClientWithTransport(address string, apiHeader, apiToken string, headers []*Header, transport http.RoundTripper) (c *Client, err error) {
+	c, err = MakeClientWithHeaders(address, apiHeader, apiToken, headers)
+	if err != nil {
+		return
+	}
+
+	c.transport = transport
 
 	return
 }
@@ -108,9 +121,11 @@ func (client *Client) submitFormRaw(ctx context.Context, path string, params int
 	queryURL := client.serverURL
 	queryURL.Path += path
 
-	var req *http.Request
-	var bodyReader io.Reader
-	var v url.Values
+	var (
+		req        *http.Request
+		bodyReader io.Reader
+		v          url.Values
+	)
 
 	if params != nil {
 		v, err = query.Values(params)
@@ -139,7 +154,7 @@ func (client *Client) submitFormRaw(ctx context.Context, path string, params int
 
 	// Supply the client token.
 	req.Header.Set(client.apiHeader, client.apiToken)
-	// Add the client headers.
+	// Add the client headers.π
 	for _, header := range client.headers {
 		req.Header.Add(header.Key, header.Value)
 	}
@@ -148,7 +163,7 @@ func (client *Client) submitFormRaw(ctx context.Context, path string, params int
 		req.Header.Add(header.Key, header.Value)
 	}
 
-	httpClient := &http.Client{}
+	httpClient := &http.Client{Transport: client.transport}
 	req = req.WithContext(ctx)
 	resp, err = httpClient.Do(req)
 

--- a/examples/overview/main.go
+++ b/examples/overview/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 
 	"github.com/algorand/go-algorand-sdk/v2/client/v2/algod"
@@ -34,8 +35,24 @@ func main() {
 		algodToken,
 		[]*common.Header{&algodHeader},
 	)
+
+	// Or, for better performance, pass a custom Transport, in this case allowing
+	// up to 100 simultaneous connections to the same host (ie: an algod node)
+	// Clone Go's default transport settings but increase connection values
+	customTransport := http.DefaultTransport.(*http.Transport).Clone()
+	customTransport.MaxIdleConns = 100
+	customTransport.MaxConnsPerHost = 100
+	customTransport.MaxIdleConnsPerHost = 100
+
+	algodClientWithCustomTransport, _ := algod.MakeClientWithTransport(
+		algodAddress,
+		algodToken,
+		nil, // accepts additional headers like MakeClientWithHeaders
+		customTransport,
+	)
 	// example: ALGOD_CREATE_CLIENT
 
+	_ = algodClientWithCustomTransport
 	_ = algodClientWithHeaders
 	_ = algodClient
 


### PR DESCRIPTION
The sdk previously only used the default http client and the default client, using the default transport has severe limitations for apps making multiple connections to the same host. This new method will allow users to pass a new Transport instance which has new values for things like MaxIdleConnsPerHost and MaxIdleConns.