### PR TITLE
bugfix: adding EvalDelta.SharedAccts

### DIFF
--- a/types/block.go
+++ b/types/block.go
@@ -259,6 +259,11 @@ type EvalDelta struct {
 	// [txn.Sender, txn.Accounts[0], txn.Accounts[1], ...]
 	LocalDeltas map[uint64]StateDelta `codec:"ld,allocbound=config.MaxEvalDeltaAccounts"`
 
+	// If a program modifies the local of an account that is not the Sender, or
+	// in txn.Accounts, it must be recorded here, so that the key in LocalDeltas
+	// can refer to it.
+	SharedAccts []Address `codec:"sa,allocbound=config.MaxEvalDeltaAccounts"`
+
 	Logs []string `codec:"lg"`
 
 	InnerTxns []SignedTxnWithAD `codec:"itx"`
@@ -266,6 +271,7 @@ type EvalDelta struct {
 
 // StateDelta is a map from key/value store keys to ValueDeltas, indicating
 // what should happen for that key
+//
 //msgp:allocbound StateDelta config.MaxStateDeltaKeys
 type StateDelta map[string]ValueDelta
 

--- a/types/block.go
+++ b/types/block.go
@@ -257,11 +257,13 @@ type EvalDelta struct {
 
 	// When decoding EvalDeltas, the integer key represents an offset into
 	// [txn.Sender, txn.Accounts[0], txn.Accounts[1], ...]
+	//msgp:allocbound LocalDeltas config.MaxEvalDeltaAccounts
 	LocalDeltas map[uint64]StateDelta `codec:"ld"`
 
 	// If a program modifies the local of an account that is not the Sender, or
 	// in txn.Accounts, it must be recorded here, so that the key in LocalDeltas
 	// can refer to it.
+	//msgp:allocbound SharedAccts config.MaxEvalDeltaAccounts
 	SharedAccts []Address `codec:"sa"`
 
 	Logs []string `codec:"lg"`

--- a/types/block.go
+++ b/types/block.go
@@ -271,7 +271,6 @@ type EvalDelta struct {
 
 // StateDelta is a map from key/value store keys to ValueDeltas, indicating
 // what should happen for that key
-//
 //msgp:allocbound StateDelta config.MaxStateDeltaKeys
 type StateDelta map[string]ValueDelta
 

--- a/types/block.go
+++ b/types/block.go
@@ -257,12 +257,12 @@ type EvalDelta struct {
 
 	// When decoding EvalDeltas, the integer key represents an offset into
 	// [txn.Sender, txn.Accounts[0], txn.Accounts[1], ...]
-	LocalDeltas map[uint64]StateDelta `codec:"ld,allocbound=config.MaxEvalDeltaAccounts"`
+	LocalDeltas map[uint64]StateDelta `codec:"ld"`
 
 	// If a program modifies the local of an account that is not the Sender, or
 	// in txn.Accounts, it must be recorded here, so that the key in LocalDeltas
 	// can refer to it.
-	SharedAccts []Address `codec:"sa,allocbound=config.MaxEvalDeltaAccounts"`
+	SharedAccts []Address `codec:"sa"`
 
 	Logs []string `codec:"lg"`
 


### PR DESCRIPTION
# Add missing field in `EvalDelta`

The Shared Resources work https://github.com/algorand/go-algorand/pull/5035 introduced a new field in `data.transactions.EvalDelta`. This PR adds it to the mirror type `types.EvalDelta`.

## Testing

As of 15May2023 there is a draft PR in go-algorand https://github.com/algorand/go-algorand/pull/5381 with a test that validates the types against this PR.