### PR TITLE
DevOps: Update CODEOWNERS to only refer to the devops group

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-.github/ @algorand/dev
-.circleci/ @algorand/dev
+.github/ @algorand/devops
+.circleci/ @algorand/devops


### PR DESCRIPTION
# Summary

Change CODEOWNERS changes to pipeline to only notify DevOps team.
