### PR TITLE
lint: Add `golangci-lint` to CI process

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,31 @@
+name: "Lint Checks"
+on:
+  pull_request:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # required for new-from-rev option in .golangci.yml
+      - name: Install specific golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.13'
+      - name: Check format
+        run: test -z `go fmt ./...`
+      - name: Vet
+        run: go vet ./...
+      - name: reviewdog-golangci-lint
+        uses: reviewdog/action-golangci-lint@v2
+        with:
+          golangci_lint_version: "v1.47.3"
+          golangci_lint_flags: "-c .golangci.yml --allow-parallel-runners"
+          go_version: "1.17.13"
+          reporter: "github-pr-review"
+          tool_name: "Lint Errors"
+          level: "error"
+          fail_on_error: true
+          filter_mode: "nofilter"
+      

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -28,4 +28,3 @@ jobs:
           level: "error"
           fail_on_error: true
           filter_mode: "nofilter"
-      

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,12 +9,15 @@ linters:
   enable:
     - deadcode
     - errcheck
+    - exportloopref
     - gci
     - gofmt
     - gosimple
     - govet
     - ineffassign
     - misspell
+    - nilerr
+    - nolintlint
     - revive
     - staticcheck
     - structcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,66 @@
+run:
+  timeout: 5m
+  tests: false
+  skip-dirs:
+    - client/v2/common
+  
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - errcheck
+    - gci
+    - gofmt
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - revive
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/algorand)
+      - prefix(github.com/algorand/go-algorand-sdk)
+
+    section-separators:
+      - newLine
+
+severity:
+  default-severity: error
+
+issues:
+  # Work our way back over time to be clean against all these
+  # checkers.  If you'd like to contribute, raise the number after ~,
+  # run the linter and dig in.
+  new-from-rev: e85d1961c86009482306497313a2e0fea5bc3dbd
+
+  # Disable default exclude rules listed in `golangci-lint run --help` (selectively re-enable some below)
+  exclude-use-default: false
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
+
+  exclude:
+    # ignore govet false positive fixed in https://github.com/golang/go/issues/45043
+    - "sigchanyzer: misuse of unbuffered os.Signal channel as argument to signal.Notify"
+    # ignore golint false positive fixed in https://github.com/golang/lint/pull/487
+    - "exported method (.*).Unwrap` should have comment or be unexported"
+    # ignore issues about the way we use _struct fields to define encoding settings
+    - "`_struct` is unused"
+
+    # Enable some golangci-lint default exception rules:
+    # "EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it's ok"
+    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
+    # "EXC0005 staticcheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore"
+    - ineffective break statement. Did you mean to break out of the outer loop

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,9 +37,7 @@ severity:
   default-severity: error
 
 issues:
-  # Work our way back over time to be clean against all these
-  # checkers.  If you'd like to contribute, raise the number after ~,
-  # run the linter and dig in.
+  # Currently checks lint errors that were committed after v2.1
   new-from-rev: e85d1961c86009482306497313a2e0fea5bc3dbd
 
   # Disable default exclude rules listed in `golangci-lint run --help` (selectively re-enable some below)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ INTEGRATIONS_TAGS := "$(shell awk '{print $2}' test/integration.tags | paste -s 
 GO_IMAGE := golang:$(subst go,,$(shell go version | cut -d' ' -f 3 | cut -d'.' -f 1,2))-stretch
 
 lint:
-	golint `go list ./... | grep -v /vendor/`
+	golangci-lint run -c .golangci.yml
+	go vet ./...
 
 fmt:
 	go fmt ./...

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ In `client/v2` the `indexer` package contains a client for the Algorand Indexer 
 
 Run tests with `make docker-test`. To set up the sandbox-based test harness without standing up the go-algorand docker image use `make harness`.
 
+We use golangci-lint to run linters on our codebase. Please run `make lint` before you submit a PR to make sure it conforms to linter standards.
+
 # Quick Start
 
 To download the SDK, open a terminal and use the `go get` command.

--- a/client/v2/algod/rawTransaction.go
+++ b/client/v2/algod/rawTransaction.go
@@ -28,7 +28,7 @@ func (s *SendRawTransaction) Do(ctx context.Context, headers ...*common.Header) 
 		}
 	}
 	if addContentType {
-		headers = append(headers, &common.Header{"Content-Type", "application/x-binary"})
+		headers = append(headers, &common.Header{Key: "Content-Type", Value: "application/x-binary"})
 	}
 	err = s.c.post(ctx, &response, "/v2/transactions", nil, headers, s.rawtxn)
 	txid = response.Txid

--- a/test/utilities.go
+++ b/test/utilities.go
@@ -197,7 +197,7 @@ func getFirstField(ob interface{}) string {
 	if ob == nil || getType(ob) != OBJECT {
 		return ""
 	}
-	for k, _ := range ob.(map[string]interface{}) {
+	for k := range ob.(map[string]interface{}) {
 		return k
 	}
 	return ""
@@ -288,17 +288,17 @@ func recursiveCompare(field string, expected, actual interface{}) error {
 		keys := make(map[string]bool)
 		if expectedType != MISSING {
 			expectedObject = expected.(map[string]interface{})
-			for k, _ := range expectedObject {
+			for k := range expectedObject {
 				keys[k] = true
 			}
 		}
 		if actualType != MISSING {
 			actualObject = actual.(map[string]interface{})
-			for k, _ := range actualObject {
+			for k := range actualObject {
 				keys[k] = true
 			}
 		}
-		for k, _ := range keys {
+		for k := range keys {
 			var err error
 			err = recursiveCompare(fmt.Sprintf("%s.%s", field, k), expectedObject[k], actualObject[k])
 			if err != nil {

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -976,11 +976,11 @@ func TestFee(t *testing.T) {
 func TestParseBoxReferences(t *testing.T) {
 
 	genWithAppId := func(appId uint64) types.AppBoxReference {
-		return types.AppBoxReference{appId, []byte("example")}
+		return types.AppBoxReference{AppID: appId, Name: []byte("example")}
 	}
 
 	genWithNewAppId := func() types.AppBoxReference {
-		return types.AppBoxReference{0, []byte("example")}
+		return types.AppBoxReference{AppID: 0, Name: []byte("example")}
 	}
 
 	t.Run("appIndexExists", func(t *testing.T) {

--- a/types/basics.go
+++ b/types/basics.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/algorand/go-algorand-sdk/v2/encoding/msgpack"
-
 	"golang.org/x/crypto/ed25519"
+
+	"github.com/algorand/go-algorand-sdk/v2/encoding/msgpack"
 )
 
 // TxType identifies the type of the transaction


### PR DESCRIPTION
Add a `lint` job to Github Actions to check for go fmt, vet and golangci-lint checks. 

The `.golangci.yml` file currently excludes generated models checks (since these cannot be hand modified easily) and checks linting errors since the v2.1 release (we will fix existing errors in another PR to make it easier for review). Otherwise, the checks were taken from [Conduit's `.golangci.yml` file](https://github.com/algorand/conduit/blob/master/.golangci.yml).

CI Job passes with no error: https://github.com/algorand/go-algorand-sdk/actions/runs/4996541721/jobs/8949856005?pr=534