### PR TITLE
chore: Add new consensus params to vFuture

### DIFF
--- a/protocol/config/consensus.go
+++ b/protocol/config/consensus.go
@@ -93,6 +93,10 @@ type ConsensusParams struct {
 	// rather than check each individual app call is within the budget.
 	EnableAppCostPooling bool
 
+	// EnableLogicSigCostPooling specifies LogicSig budgets are pooled across a
+	// group. The total available is len(group) * LogicSigMaxCost)
+	EnableLogicSigCostPooling bool
+
 	// RewardUnit specifies the number of MicroAlgos corresponding to one reward
 	// unit.
 	//
@@ -1230,6 +1234,7 @@ func initConsensusProtocols() {
 	vFuture.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 
 	vFuture.LogicSigVersion = 10 // When moving this to a release, put a new higher LogicSigVersion here
+	vFuture.EnableLogicSigCostPooling = true
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 


### PR DESCRIPTION
Adds new consensus fields from https://github.com/algorand/go-algorand/pull/5528/files#diff-a75ef7294adbd7ae646c49ae2a518253936983c0a16594b84f20f15403767a2f 