### PR TITLE
protocol: Add block hash to state proof's LightBlockHeader

### DIFF
--- a/protocol/config/consensus.go
+++ b/protocol/config/consensus.go
@@ -400,6 +400,11 @@ type ConsensusParams struct {
 	// their account balances.
 	StateProofExcludeTotalWeightWithRewards bool
 
+	// StateProofBlockHashInLightHeader specifies that the LightBlockHeader
+	// committed to by state proofs should contain the BlockHash of each
+	// block, instead of the seed.
+	StateProofBlockHashInLightHeader bool
+
 	// EnableAssetCloseAmount adds an extra field to the ApplyData. The field contains the amount of the remaining
 	// asset that were sent to the close-to address.
 	EnableAssetCloseAmount bool

--- a/types/lightBlockHeader.go
+++ b/types/lightBlockHeader.go
@@ -11,6 +11,7 @@ type LightBlockHeader struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
 	Seed                Seed   `codec:"0"`
+	BlockHash           Digest `codec:"1"`
 	RoundNumber         Round  `codec:"r"`
 	GenesisHash         Digest `codec:"gh"`
 	Sha256TxnCommitment Digest `codec:"tc,allocbound=Sha256Size"`


### PR DESCRIPTION
To go along with https://github.com/algorand/go-algorand/pull/5663