### PR TITLE
types: Reject non canonical addresses in DecodeAddress

### DIFF
--- a/types/address.go
+++ b/types/address.go
@@ -65,7 +65,8 @@ func (a *Address) UnmarshalText(text []byte) error {
 }
 
 // DecodeAddress turns a checksum address string into an Address object. It
-// checks that the checksum is correct, and returns an error if it's not.
+// checks that the checksum is correct and whether the address is canonical,
+// and returns an error if it's not.
 func DecodeAddress(addr string) (a Address, err error) {
 	// Interpret the address as base32
 	decoded, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(addr)

--- a/types/address.go
+++ b/types/address.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha512"
 	"encoding/base32"
 	"encoding/base64"
+	"fmt"
 )
 
 const (
@@ -94,6 +95,13 @@ func DecodeAddress(addr string) (a Address, err error) {
 
 	// Checksum is good, copy address bytes into output
 	copy(a[:], addressBytes)
+
+	// Check if address is canonical
+	if a.String() != addr {
+		err = fmt.Errorf("address %s is non-canonical", addr)
+		return
+	}
+
 	return a, nil
 }
 

--- a/types/address_test.go
+++ b/types/address_test.go
@@ -92,3 +92,18 @@ func TestUnmarshalAddress(t *testing.T) {
 		})
 	}
 }
+
+func TestDecodeNonCanonicalAddress(t *testing.T) {
+	// Canonical addresses must end with one of the following: "AEIMQUY4",
+	// e.g. "7HJBGRIWI7GDL42SOJNIAZ7LJ7EBEGKGE5S52QZXAWDXOHDKMDFR6AUXDE"
+	addrs := []string{
+		"7HJBGRIWI7GDL42SOJNIAZ7LJ7EBEGKGE5S52QZXAWDXOHDKMDFR6AUXDF",
+		"7HJBGRIWI7GDL42SOJNIAZ7LJ7EBEGKGE5S52QZXAWDXOHDKMDFR6AUXDG",
+		"7HJBGRIWI7GDL42SOJNIAZ7LJ7EBEGKGE5S52QZXAWDXOHDKMDFR6AUXDH",
+	}
+	for _, addr := range addrs {
+		_, err := DecodeAddress(addr)
+		require.Error(t, err)
+		require.ErrorContains(t, err, fmt.Sprintf("address %s is non-canonical", addr))
+	}
+}


### PR DESCRIPTION
Checks that the address to decode is a canonical representation (least significant bit is 00, i.e. the ending character is one of "AEIMQUY4"). Adds a test to check that non-canonical addresses are rejected.

Note that the server (and most goal commands) will [reject non-canonical addresses](https://github.com/algorand/go-algorand/blob/master/data/basics/address.go#L75), but our SDK clients don't seem to check this.

Closes https://github.com/algorand/go-algorand-sdk/issues/274