### PR TITLE
Simulate: Fix simulate request error & support ATC simulation

### DIFF
--- a/client/v2/algod/simulateTransaction.go
+++ b/client/v2/algod/simulateTransaction.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/algorand/go-algorand-sdk/v2/client/v2/common"
 	"github.com/algorand/go-algorand-sdk/v2/client/v2/common/models"
+	"github.com/algorand/go-algorand-sdk/v2/encoding/msgpack"
 )
 
 // SimulateTransactionParams contains all of the query parameters for url serialization.
@@ -28,6 +29,6 @@ type SimulateTransaction struct {
 
 // Do performs the HTTP request
 func (s *SimulateTransaction) Do(ctx context.Context, headers ...*common.Header) (response models.SimulateResponse, err error) {
-	err = s.c.post(ctx, &response, "/v2/transactions/simulate", s.p, headers, s.request)
+	err = s.c.post(ctx, &response, "/v2/transactions/simulate", s.p, headers, msgpack.Encode(&s.request))
 	return
 }

--- a/client/v2/common/common.go
+++ b/client/v2/common/common.go
@@ -16,10 +16,11 @@ import (
 
 // rawRequestPaths is a set of paths where the body should not be urlencoded
 var rawRequestPaths = map[string]bool{
-	"/v2/transactions":     true,
-	"/v2/teal/compile":     true,
-	"/v2/teal/disassemble": true,
-	"/v2/teal/dryrun":      true,
+	"/v2/transactions":          true,
+	"/v2/teal/compile":          true,
+	"/v2/teal/disassemble":      true,
+	"/v2/teal/dryrun":           true,
+	"/v2/transactions/simulate": true,
 }
 
 // Header is a struct for custom headers.

--- a/test/applications_integration_test.go
+++ b/test/applications_integration_test.go
@@ -495,7 +495,7 @@ func iExecuteTheCurrentTransactionGroupWithTheComposer() error {
 }
 
 func iSimulateTheCurrentTransactionGroupWithTheComposer() error {
-	result, err := txComposer.Simulate(algodV2client, context.Background(), models.SimulateRequest{})
+	result, err := txComposer.Simulate(context.Background(), algodV2client, models.SimulateRequest{})
 	if err != nil {
 		return err
 	}

--- a/test/integration.tags
+++ b/test/integration.tags
@@ -13,3 +13,4 @@
 @rekey_v1
 @send
 @send.keyregtxn
+@simulate

--- a/transaction/atomicTransactionComposer.go
+++ b/transaction/atomicTransactionComposer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/algorand/go-algorand-sdk/v2/client/v2/algod"
 	"github.com/algorand/go-algorand-sdk/v2/client/v2/common/models"
 	"github.com/algorand/go-algorand-sdk/v2/crypto"
+	"github.com/algorand/go-algorand-sdk/v2/encoding/msgpack"
 	"github.com/algorand/go-algorand-sdk/v2/types"
 )
 
@@ -100,6 +101,16 @@ type AddMethodCallParams struct {
 
 	// References of the boxes to be accessed by this method call.
 	BoxReferences []types.AppBoxReference
+}
+
+// SimulateResult contains the results of calling the Simulate method on an
+// AtomicTransactionComposer object.
+type SimulateResult struct {
+	// The result of the transaction group simulation
+	SimulateResponse models.SimulateResponse
+	// For each ABI method call in the executed group (created by the AddMethodCall method), this
+	// slice contains information about the method call's return value
+	MethodResults []ABIMethodResult
 }
 
 // ExecuteResult contains the results of successfully calling the Execute method on an
@@ -573,6 +584,64 @@ func (atc *AtomicTransactionComposer) Submit(client *algod.Client, ctx context.C
 	return atc.getTxIDs(), nil
 }
 
+// Simulate simulates the transaction group in the network.
+//
+// The composer's status must be SUBMITTED or lower before calling this method. Simulation will not
+// advance the status of the composer beyond SIGNED.
+//
+// The `request` argument can be used to customize the characteristics of the simulation.
+//
+// Returns a models.SimulateResponse and an ABIResult for each method call in this group.
+func (atc *AtomicTransactionComposer) Simulate(client *algod.Client, ctx context.Context, request models.SimulateRequest) (SimulateResult, error) {
+	if atc.status > SUBMITTED {
+		return SimulateResult{}, errors.New("status must be SUBMITTED or lower in order to call Simulate()")
+	}
+
+	stxs, err := atc.GatherSignatures()
+	if err != nil {
+		return SimulateResult{}, err
+	}
+
+	txnObjects := make([]types.SignedTxn, len(stxs))
+	for i, stx := range stxs {
+		var txnObject types.SignedTxn
+		err = msgpack.Decode(stx, &txnObject)
+		if err != nil {
+			return SimulateResult{}, err
+		}
+		txnObjects[i] = txnObject
+	}
+
+	request.TxnGroups = []models.SimulateRequestTransactionGroup{
+		{Txns: txnObjects},
+	}
+
+	simulateResponse, err := client.SimulateTransaction(request).Do(ctx)
+	if err != nil {
+		return SimulateResult{}, err
+	}
+
+	result := SimulateResult{
+		SimulateResponse: simulateResponse,
+	}
+
+	for i, txContext := range atc.txContexts {
+		// Verify method call is available. This may not be the case if the App Call Tx wasn't created
+		// by AddMethodCall().
+		if !txContext.isMethodCallTx() {
+			continue
+		}
+
+		methodResult := ABIMethodResult{TxID: txContext.txID(), Method: *txContext.method}
+		txnInfo := models.PendingTransactionInfoResponse(simulateResponse.TxnGroups[0].TxnResults[i].TxnResult)
+
+		methodResult = prepareMethodResult(methodResult, txnInfo)
+		result.MethodResults = append(result.MethodResults, methodResult)
+	}
+
+	return result, nil
+}
+
 // Execute sends the transaction group to the network and waits until it's committed to a block. An
 // error will be thrown if submission or execution fails.
 //
@@ -642,39 +711,42 @@ func (atc *AtomicTransactionComposer) Execute(client *algod.Client, ctx context.
 			result.TransactionInfo = methodCallInfo
 		}
 
-		if txContext.method.Returns.IsVoid() {
-			result.RawReturnValue = []byte{}
-			executeResponse.MethodResults = append(executeResponse.MethodResults, result)
-			continue
-		}
-
-		if len(result.TransactionInfo.Logs) == 0 {
-			result.DecodeError = errors.New("method call did not log a return value")
-			executeResponse.MethodResults = append(executeResponse.MethodResults, result)
-			continue
-		}
-
-		lastLog := result.TransactionInfo.Logs[len(result.TransactionInfo.Logs)-1]
-		if !bytes.HasPrefix(lastLog, abiReturnHash) {
-			result.DecodeError = errors.New("method call did not log a return value")
-			executeResponse.MethodResults = append(executeResponse.MethodResults, result)
-			continue
-		}
-
-		result.RawReturnValue = lastLog[len(abiReturnHash):]
-
-		abiType, err := txContext.method.Returns.GetTypeObject()
-		if err != nil {
-			result.DecodeError = err
-			executeResponse.MethodResults = append(executeResponse.MethodResults, result)
-			break
-		}
-
-		result.ReturnValue, result.DecodeError = abiType.Decode(result.RawReturnValue)
+		result = prepareMethodResult(result, result.TransactionInfo)
 		executeResponse.MethodResults = append(executeResponse.MethodResults, result)
 	}
 
 	return executeResponse, nil
+}
+
+func prepareMethodResult(result ABIMethodResult, transactionInfo models.PendingTransactionInfoResponse) ABIMethodResult {
+	result.TransactionInfo = transactionInfo
+
+	if result.Method.Returns.IsVoid() {
+		result.RawReturnValue = []byte{}
+		return result
+	}
+
+	if len(result.TransactionInfo.Logs) == 0 {
+		result.DecodeError = errors.New("method call did not log a return value")
+		return result
+	}
+
+	lastLog := result.TransactionInfo.Logs[len(result.TransactionInfo.Logs)-1]
+	if !bytes.HasPrefix(lastLog, abiReturnHash) {
+		result.DecodeError = errors.New("method call did not log a return value")
+		return result
+	}
+
+	result.RawReturnValue = lastLog[len(abiReturnHash):]
+
+	abiType, err := result.Method.Returns.GetTypeObject()
+	if err != nil {
+		result.DecodeError = err
+		return result
+	}
+
+	result.ReturnValue, result.DecodeError = abiType.Decode(result.RawReturnValue)
+	return result
 }
 
 // marshallAbiUint64 converts any value used to represent an ABI "uint64" into

--- a/transaction/atomicTransactionComposer.go
+++ b/transaction/atomicTransactionComposer.go
@@ -584,7 +584,7 @@ func (atc *AtomicTransactionComposer) Submit(client *algod.Client, ctx context.C
 	return atc.getTxIDs(), nil
 }
 
-// Simulate simulates the transaction group in the network.
+// Simulate simulates the transaction group against the network.
 //
 // The composer's status must be SUBMITTED or lower before calling this method. Simulation will not
 // advance the status of the composer beyond SIGNED.

--- a/transaction/atomicTransactionComposer.go
+++ b/transaction/atomicTransactionComposer.go
@@ -592,7 +592,7 @@ func (atc *AtomicTransactionComposer) Submit(client *algod.Client, ctx context.C
 // The `request` argument can be used to customize the characteristics of the simulation.
 //
 // Returns a models.SimulateResponse and an ABIResult for each method call in this group.
-func (atc *AtomicTransactionComposer) Simulate(client *algod.Client, ctx context.Context, request models.SimulateRequest) (SimulateResult, error) {
+func (atc *AtomicTransactionComposer) Simulate(ctx context.Context, client *algod.Client, request models.SimulateRequest) (SimulateResult, error) {
 	if atc.status > SUBMITTED {
 		return SimulateResult{}, errors.New("status must be SUBMITTED or lower in order to call Simulate()")
 	}

--- a/transaction/transactionSigner.go
+++ b/transaction/transactionSigner.go
@@ -162,7 +162,7 @@ func (txSigner EmptyTransactionSigner) SignTransactions(txGroup []types.Transact
 		stx := types.SignedTxn{
 			Txn: txGroup[pos],
 		}
-		stxs[i] = msgpack.Encode(stx)
+		stxs[i] = msgpack.Encode(&stx)
 	}
 	return stxs, nil
 }

--- a/transaction/transactionSigner.go
+++ b/transaction/transactionSigner.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/algorand/go-algorand-sdk/v2/crypto"
+	"github.com/algorand/go-algorand-sdk/v2/encoding/msgpack"
 	"github.com/algorand/go-algorand-sdk/v2/types"
 )
 
@@ -148,4 +149,26 @@ func (txSigner MultiSigAccountTransactionSigner) Equals(other TransactionSigner)
 		return string(otherJSON) == string(selfJSON)
 	}
 	return false
+}
+
+// EmptyTransactionSigner is a TransactionSigner that produces signed transaction objects without
+// signatures. This is useful for simulating transactions, but it won't work for actual submission.
+type EmptyTransactionSigner struct{}
+
+// SignTransactions returns SignedTxn bytes but does not sign them.
+func (txSigner EmptyTransactionSigner) SignTransactions(txGroup []types.Transaction, indexesToSign []int) ([][]byte, error) {
+	stxs := make([][]byte, len(indexesToSign))
+	for i, pos := range indexesToSign {
+		stx := types.SignedTxn{
+			Txn: txGroup[pos],
+		}
+		stxs[i] = msgpack.Encode(stx)
+	}
+	return stxs, nil
+}
+
+// Equals returns true if the other TransactionSigner equals this one.
+func (txSigner EmptyTransactionSigner) Equals(other TransactionSigner) bool {
+	_, ok := other.(EmptyTransactionSigner)
+	return ok
 }


### PR DESCRIPTION
A user reported that the following error occurred when trying to use the algod simulate endpoint:

```
HTTP 400: {"message":"failed to decode object: json decode error [pos 13]: no matching struct field found when decoding stream map with key Format"}
```

I reproduced the error and saw that it was because the simulate endpoint needed to be added to `rawRequestPaths`, otherwise the code uses the query params as the POST body. This required a code generation change as well: https://github.com/algorand/generator/pull/68

In order to add coverage, I enabled the `@simulate` cucumber tests and added the necessary step defs.

Note that these tests also cover simulating with the `AtomicTransactionComposer`, which this SDK didn't support. Instead of modifying the test tags to separate this out (and updating the other SDKs' tags), I ended up implementing the missing feature instead.