### PR TITLE
feat: add min-balance to account information model

### DIFF
--- a/client/v2/common/models/account.go
+++ b/client/v2/common/models/account.go
@@ -54,6 +54,10 @@ type Account struct {
 	// Deleted whether or not this account is currently closed.
 	Deleted bool `json:"deleted,omitempty"`
 
+	// MinBalance MicroAlgo balance required by the account. The requirement grows
+	// based on asset and application usage.
+	MinBalance uint64 `json:"min-balance"`
+
 	// Participation accountParticipation describes the parameters used by this account
 	// in consensus protocol.
 	Participation AccountParticipation `json:"participation,omitempty"`


### PR DESCRIPTION
## Summary

Simply exposes the `min-balance` in the [`Account`](https://github.com/algorand/go-algorand-sdk/blob/develop/client/v2/common/models/account.go) model as defined in the REST API [response](https://developer.algorand.org/docs/rest-apis/algod/#account).

As the API defines the `min-balance` as required, there should always be a value. As of now (19th January 2024), minimum balance should always be >= 100,000 microAlgos.

Closes [#272](https://github.com/algorand/go-algorand-sdk/issues/272).