### PR TITLE
Build: Bump go version for builds/workflows to 1.20.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
           name: 'test_go_<< matrix.go_version >>'
           matrix:
             parameters:
-              go_version: ['1.20.5']
+              go_version: ['1.20.14']
 
 jobs:
   test:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install specific golang
         uses: actions/setup-go@v4.0.1
         with:
-          go-version: '1.20.5'
+          go-version: '1.20.14'
       - name: Check format
         run: test -z `go fmt ./...`
       - name: Vet
@@ -22,7 +22,7 @@ jobs:
         with:
           golangci_lint_version: "v1.53.2"
           golangci_lint_flags: "-c .golangci.yml --allow-parallel-runners"
-          go_version: "1.20.5"
+          go_version: "1.20.14"
           reporter: "github-pr-review"
           tool_name: "Lint Errors"
           level: "error"

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_IMAGE=golang:1.20.5
+ARG GO_IMAGE=golang:1.20.14
 FROM $GO_IMAGE
 
 # Copy SDK code into the container


### PR DESCRIPTION
Bump go version for builds/workflows to 1.20.14

Existing tests/builds should succeed.