### PR TITLE
tests: cross-sdk heartbeat tests

### DIFF
--- a/test/unit.tags
+++ b/test/unit.tags
@@ -2,6 +2,8 @@
 @unit.abijson.byname
 @unit.algod
 @unit.algod.ledger_refactoring
+@unit.algod.heartbeat
+@unit.algod.heartbeat.msgp
 @unit.applications
 @unit.applications.boxes
 @unit.atomic_transaction_composer
@@ -14,6 +16,7 @@
 @unit.indexer.ledger_refactoring
 @unit.indexer.logs
 @unit.indexer.rekey
+@unit.indexer.heartbeat
 @unit.offline
 @unit.program_sanity_check
 @unit.ready


### PR DESCRIPTION
Cross SDK tests, corresponding PR https://github.com/algorand/algorand-sdk-testing/pull/316

I had to fix the `weMakeAnyGetBlockCall` implementation to use a special mock block request that supports both JSON and MSGP. Unfortunately, there is no good way of determining the mock data content type so had to check the mocked payload for `{` symbol at the beginning to switch to JSON request. 
