### PR TITLE
Sdk release updates

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -50,7 +50,7 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           PULL_REQUEST_URL=$(gh pr create --base "main" \
-            --title "Changelog: Merge changelog for ${{ github.event.repository.name }} $RELEASE_TAG to main" \
+            --title "CHANGELOG: Merge changelog for ${{ github.event.repository.name }} $RELEASE_TAG to main" \
             --label "Skip-Release-Notes" \
             --body "Merge changelog updates to main." | tail -n 1)
           if [[ $PULL_REQUEST_URL =~ ^https://github.com/${{ github.repository }}/pull/[0-9]+$ ]]; then

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,5 +1,5 @@
-# .github/workflows/update-changelog.yaml
-name: "Update Changelog off release notes"
+# .github/workflows/post-release.yml
+name: "Post release changelog update"
 
 on:
   release:

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,63 @@
+# .github/workflows/update-changelog.yaml
+name: "Update Changelog off release notes"
+
+on:
+  release:
+    types: [released]
+
+env:
+  CHANGELOG_BRANCH: "changelog/"+${{ github.event.release.tag_name }}
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.target_commitish }}
+
+      - name: Create changelog update branch if it does not exist
+        run: |
+          if ! git show-ref --verify --quiet "refs/remotes/origin/$CHANGELOG_BRANCH"; then
+            git checkout -b $CHANGELOG_BRANCH
+            git push --set-upstream origin $CHANGELOG_BRANCH
+          elif [[ $(git rev-parse --abbrev-ref HEAD) != "$CHANGELOG_BRANCH" ]]; then
+            echo "Current Branch: $(git rev-parse --abbrev-ref HEAD)"
+            echo "Changelog branch exists, make sure you're using the workflow from the changelog branch or delete the existing changelog branch."
+            exit 1
+          else
+            echo "Changelog branch exists and used as workflow ref."
+          fi
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.tag_name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: $CHANGELOG_BRANCH
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGELOG.md
+
+      - name: Create Pull Request to Main
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          PULL_REQUEST_URL=$(gh pr create --base "main" \
+            --title "Changelog: Merge changelog for ${{ github.event.repository.name }} $RELEASE_TAG to main" \
+            --label "Skip-Release-Notes" \
+            --body "Merge changelog updates to main." | tail -n 1)
+          if [[ $PULL_REQUEST_URL =~ ^https://github.com/${{ github.repository }}/pull/[0-9]+$ ]]; then
+            echo "Pull request to Main created: $PULL_REQUEST_URL"
+            MAIN_PR_MESSAGE="\nPull Request to main: $PULL_REQUEST_URL"
+            echo "pull-request-main-message=$MAIN_PR_MESSAGE" >> $GITHUB_ENV
+          else
+            echo "There was an issue creating the pull request to main branch."
+            exit 1
+          fi

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -6,7 +6,7 @@ on:
     types: [released]
 
 env:
-  CHANGELOG_BRANCH: "changelog/"+${{ github.event.release.tag_name }}
+  CHANGELOG_BRANCH: "changelog/${{ github.event.release.tag_name }}"
 
 jobs:
   update-changelog:

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -6,7 +6,7 @@ on:
     types: [released]
 
 env:
-  CHANGELOG_BRANCH: "changelog/${{ github.event.release.tag_name }}"
+  CHANGELOG_BRANCH: changelog/${{ github.event.release.tag_name }}
 
 jobs:
   update-changelog:
@@ -37,12 +37,12 @@ jobs:
           latest-version: ${{ github.event.release.tag_name }}
           release-notes: ${{ github.event.release.body }}
 
-      - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Commit Changes
+        uses: EndBug/add-and-commit@v9.1.3
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         with:
-          branch: $CHANGELOG_BRANCH
-          commit_message: Update CHANGELOG
-          file_pattern: CHANGELOG.md
+          message: "Update changelog for ${{ env.RELEASE_TAG }}"
 
       - name: Create Pull Request to Main
         env:

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -51,7 +51,6 @@ jobs:
         run: |
           PULL_REQUEST_URL=$(gh pr create --base "main" \
             --title "Changelog: Merge changelog for ${{ github.event.repository.name }} $RELEASE_TAG to main" \
-            --label "Skip-Release-Notes" \
             --body "Merge changelog updates to main." | tail -n 1)
           if [[ $PULL_REQUEST_URL =~ ^https://github.com/${{ github.repository }}/pull/[0-9]+$ ]]; then
             echo "Pull request to Main created: $PULL_REQUEST_URL"

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           PULL_REQUEST_URL=$(gh pr create --base "main" \
             --title "Changelog: Merge changelog for ${{ github.event.repository.name }} $RELEASE_TAG to main" \
+            --label "Skip-Release-Notes" \
             --body "Merge changelog updates to main." | tail -n 1)
           if [[ $PULL_REQUEST_URL =~ ^https://github.com/${{ github.repository }}/pull/[0-9]+$ ]]; then
             echo "Pull request to Main created: $PULL_REQUEST_URL"


### PR DESCRIPTION
## Summary
Introduce post-release.yml for generating a changelog update PR back to the main line after a release finishes. Intent is to have the entry changelog on the Github releases page align with the entry in `CHANGELOG.md`.

## Test Plan

Ran action on my fork (with skip-release-notes label disabled); ensured completed successfully and generated PR.