### PR TITLE
Build: Update Box API Pagination-dependent integration tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ workflows:
 jobs:
   test:
     machine:
-      image: "ubuntu-2404:2024.05.1"
+      image: "ubuntu-2404:2024.11.1"
     parameters:
       go_version:
         type: string

--- a/test/applications_integration_test.go
+++ b/test/applications_integration_test.go
@@ -853,7 +853,11 @@ func currentApplicationShouldHaveFollowingBoxes(fromClient, encodedBoxesRaw stri
 	var err error
 
 	if fromClient == "algod" {
-		r, err = algodV2client.GetApplicationBoxes(applicationId).Do(context.Background())
+		var boxResponse *models.BoxesResponse
+		boxResponse, err = advanceChainAndWaitForBoxesToBeAvailable(len(expectedNames))
+		if err == nil {
+			r = *boxResponse
+		}
 	} else if fromClient == "indexer" {
 		r, err = indexerV2client.SearchForApplicationBoxes(applicationId).Do(context.Background())
 	} else {
@@ -877,6 +881,51 @@ func currentApplicationShouldHaveFollowingBoxes(fromClient, encodedBoxesRaw stri
 	}
 
 	return nil
+}
+
+func advanceChainAndWaitForBoxesToBeAvailable(expectedBoxLength int) (*models.BoxesResponse, error) {
+	maxRoundsToAdvance := 50
+	for i := 0; i < maxRoundsToAdvance; i++ {
+		params, err := algodV2client.SuggestedParams().Do(context.Background())
+		if err != nil {
+			return nil, err
+		}
+
+		txn, err := transaction.MakePaymentTxn(transientAccount.Address.String(), transientAccount.Address.String(),
+			uint64(0), nil, "", params)
+		if err != nil {
+			return nil, err
+		}
+
+		_, lstx, err := crypto.SignTransaction(transientAccount.PrivateKey, txn)
+		if err != nil {
+			return nil, err
+		}
+
+		txid, err = algodV2client.SendRawTransaction(lstx).Do(context.Background())
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = transaction.WaitForConfirmation(algodV2client, txid, 1, context.Background())
+
+		// MaxAccountLookback is 4, we start checking for our boxes after the 5th round from create transaction
+		if i > 5 {
+			r, err := algodV2client.GetApplicationBoxes(applicationId).Do(context.Background())
+			if err != nil {
+				return nil, err
+			}
+
+			if len(r.Boxes) == expectedBoxLength {
+				return &r, nil
+			} else {
+				// Sleep for 1 second and try again
+				time.Sleep(time.Second)
+			}
+		}
+	}
+
+	return nil, errors.New("timeout waiting for boxes to become available")
 }
 
 func waitForIndexerToCatchUp() error {

--- a/test/applications_integration_test.go
+++ b/test/applications_integration_test.go
@@ -918,10 +918,9 @@ func advanceChainAndWaitForBoxesToBeAvailable(expectedBoxLength int) (*models.Bo
 
 			if len(r.Boxes) == expectedBoxLength {
 				return &r, nil
-			} else {
-				// Sleep for 1 second and try again
-				time.Sleep(time.Second)
 			}
+			// Sleep for 1 second and try again
+			time.Sleep(time.Second)
 		}
 	}
 


### PR DESCRIPTION
The pagination support on the boxes endpoint depends solely on what box information has been persisted within algod. Previously, integration tests could assume once a transaction to add a box was approved, it was queryable. This PR introduces check and wait semantics to give ample time for the boxes to be made available via API.