### PR TITLE
CICD: update golang and implement tests in GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
           name: 'test_go_<< matrix.go_version >>'
           matrix:
             parameters:
-              go_version: ['1.23.3']
+              go_version: ['1.23.9']
 
 jobs:
   test:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -23,8 +23,11 @@ jobs:
         with:
           go-version: ${{ matrix.go_version }}
       
-      - name: Verify Go installation
-        run: go version
-      
-      - name: Run tests
+      - name: Unit Tests
+        run: make unit
+
+      - name: Integration Tests
+        run: make integration
+
+      - name: Run Smoke Tests
         run: make ci-test

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  GO_VERSION: '1.23.8'
+  GO_VERSION: '1.23.9'
 
 jobs:
   test:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -26,5 +26,5 @@ jobs:
       - name: Verify Go installation
         run: go version
       
-      - name: Run docker tests
-        run: make docker-test
+      - name: Run tests
+        run: make ci-test

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,30 @@
+name: Build and Test
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: 'test_go_${{ matrix.go_version }}'
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        go_version: ['1.23.8']
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go_version }}
+      
+      - name: Verify Go installation
+        run: go version
+      
+      - name: Run docker tests
+        run: make docker-test

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -6,13 +6,13 @@ on:
   push:
     branches: [ main ]
 
+env:
+  GO_VERSION: '1.23.8'
+
 jobs:
   test:
-    name: 'test_go_${{ matrix.go_version }}'
+    name: 'test_go_${{ env.GO_VERSION }}'
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        go_version: ['1.23.8']
     
     steps:
       - name: Checkout code
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go_version }}
+          go-version: ${{ env.GO_VERSION }}
       
       - name: Unit Tests
         run: make unit

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Test Suite
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ env:
 
 jobs:
   test:
-    name: 'test_go_${{ env.GO_VERSION }}'
+    name: Run Test Suites
     runs-on: ubuntu-24.04
     
     steps:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -23,10 +23,10 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       
-      - name: Unit Tests
+      - name: Run Unit Tests
         run: make unit
 
-      - name: Integration Tests
+      - name: Run Integration Tests
         run: make integration
 
       - name: Run Smoke Tests

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,6 @@ smoke-test-examples:
 
 docker-test: harness docker-gosdk-build docker-gosdk-run
 
-ci-test: unit integration harness smoke-test-examples
+ci-test: harness smoke-test-examples
 
 .PHONY: test fmt

--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,4 @@ docker-test: harness docker-gosdk-build docker-gosdk-run
 
 ci-test: harness smoke-test-examples
 
-.PHONY: test fmt
+.PHONY: test fmt ci-test

--- a/Makefile
+++ b/Makefile
@@ -51,5 +51,6 @@ smoke-test-examples:
 
 docker-test: harness docker-gosdk-build docker-gosdk-run
 
+ci-test: unit integration harness smoke-test-examples
 
 .PHONY: test fmt

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ docker-gosdk-build:
 
 docker-gosdk-run:
 	docker ps -a
-	docker run -it --network host go-sdk-testing:latest
+	docker run -t --network host go-sdk-testing:latest
 
 smoke-test-examples:
 	cd "$(SRCPATH)/examples" && bash smoke_test.sh && cd -

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/algorand/go-algorand-sdk/v2
 
 go 1.23.0
 
-toolchain go1.23.3
+toolchain go1.23.9
 
 require (
 	github.com/algorand/avm-abi v0.2.0

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,10 +1,10 @@
-ARG GO_IMAGE=golang:1.23.3
+ARG GO_IMAGE=golang:1.23.8
 FROM $GO_IMAGE
 
 # Copy SDK code into the container
-RUN mkdir -p $HOME/go-algorand-sdk
-COPY . $HOME/go-algorand-sdk
-WORKDIR $HOME/go-algorand-sdk
+RUN mkdir -p /app/go-algorand-sdk
+COPY . /app/go-algorand-sdk
+WORKDIR /app/go-algorand-sdk
 
 # Run integration tests
 CMD ["/bin/bash", "-c", "make unit && make integration && make smoke-test-examples"]

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_IMAGE=golang:1.23.8
+ARG GO_IMAGE=golang:1.23.9
 FROM $GO_IMAGE
 
 # Copy SDK code into the container


### PR DESCRIPTION
## Summary

This PR implements the go-algorand-sdk tests in GitHub Actions. It includes the following changes:

- Runs on Golang 1.23.9 / Ubuntu 24.04
- Splits Unit Tests, Integration Tests, and Smoke Tests into separate steps
- Adds a new ci-test target that runs smoke tests locally (still uses sandbox)
- Use the new ci-test target instead of the docker build
- Fixes the workdir for the Dockerfile

This is meant to be run in parallel with CircleCI to compare execution.

## Testing

Verify these tests run, as well as CircleCI's.

