### PR TITLE
types: add txn.Access constructor

### DIFF
--- a/transaction/atomicTransactionComposer.go
+++ b/transaction/atomicTransactionComposer.go
@@ -105,10 +105,10 @@ type AddMethodCallParams struct {
 	// If true, the transaction will be created with the Access field
 	UseAccess bool
 	// The asset holdings to be accessed by this method call.
-	// The zero address means the sender.
+	// The zero address means the sender. Not used if UseAccess is false.
 	Holdings []types.AppHoldingRef
 	// The local states to be accessed by this method call.
-	// The zero address means the sender.
+	// The zero address means the sender. Not used if UseAccess is false.
 	Locals []types.AppLocalsRef
 }
 

--- a/transaction/atomicTransactionComposer.go
+++ b/transaction/atomicTransactionComposer.go
@@ -105,7 +105,7 @@ type AddMethodCallParams struct {
 	// If true, the transaction will be created with the Access field
 	UseAccess bool
 	// The asset holdings to be accessed by this method call.
-	// An empty address means the sender.
+	// The zero address means the sender.
 	Holdings []types.AppHoldingRef
 	// The local states to be accessed by this method call.
 	// An empty address means the sender.

--- a/transaction/atomicTransactionComposer.go
+++ b/transaction/atomicTransactionComposer.go
@@ -101,6 +101,15 @@ type AddMethodCallParams struct {
 
 	// References of the boxes to be accessed by this method call.
 	BoxReferences []types.AppBoxReference
+
+	// If true, the transaction will be created with the Access field
+	UseAccess bool
+	// The asset holdings to be accessed by this method call.
+	// An empty address means the sender.
+	Holdings []types.AppHoldingRef
+	// The local states to be accessed by this method call.
+	// An empty address means the sender.
+	Locals []types.AppLocalsRef
 }
 
 // SimulateResult contains the results of calling the Simulate method on an
@@ -350,6 +359,11 @@ func (atc *AtomicTransactionComposer) AddMethodCall(params AddMethodCallParams) 
 	if err != nil {
 		return err
 	}
+
+	if len(refArgsResolved) != 0 && params.UseAccess {
+		return fmt.Errorf("cannot use reference arguments with Access field transaction")
+	}
+
 	for i, resolved := range refArgsResolved {
 		basicArgIndex := refArgIndexToBasicArgIndex[i]
 		// use the foreign array index as the encoded argument value
@@ -387,25 +401,52 @@ func (atc *AtomicTransactionComposer) AddMethodCall(params AddMethodCallParams) 
 		encodedAbiArgs = append(encodedAbiArgs, encodedArg)
 	}
 
-	tx, err := MakeApplicationCallTxWithBoxes(
-		params.AppID,
-		encodedAbiArgs,
-		foreignAccounts,
-		foreignApps,
-		foreignAssets,
-		params.BoxReferences,
-		params.OnComplete,
-		params.ApprovalProgram,
-		params.ClearProgram,
-		params.GlobalSchema,
-		params.LocalSchema,
-		params.ExtraPages,
-		params.SuggestedParams,
-		params.Sender,
-		params.Note,
-		types.Digest{},
-		params.Lease,
-		params.RekeyTo)
+	var tx types.Transaction
+	if params.UseAccess {
+		// Access field transaction without reference args
+		tx, err = MakeApplicationCallTxWithAccess(
+			params.AppID,
+			encodedAbiArgs,
+			foreignAccounts,
+			foreignApps,
+			foreignAssets,
+			params.BoxReferences,
+			params.Holdings,
+			params.Locals,
+			params.OnComplete,
+			params.ApprovalProgram,
+			params.ClearProgram,
+			params.GlobalSchema,
+			params.LocalSchema,
+			params.ExtraPages,
+			params.SuggestedParams,
+			params.Sender,
+			params.Note,
+			types.Digest{},
+			params.Lease,
+			params.RekeyTo)
+
+	} else {
+		tx, err = MakeApplicationCallTxWithBoxes(
+			params.AppID,
+			encodedAbiArgs,
+			foreignAccounts,
+			foreignApps,
+			foreignAssets,
+			params.BoxReferences,
+			params.OnComplete,
+			params.ApprovalProgram,
+			params.ClearProgram,
+			params.GlobalSchema,
+			params.LocalSchema,
+			params.ExtraPages,
+			params.SuggestedParams,
+			params.Sender,
+			params.Note,
+			types.Digest{},
+			params.Lease,
+			params.RekeyTo)
+	}
 	if err != nil {
 		return err
 	}

--- a/transaction/atomicTransactionComposer.go
+++ b/transaction/atomicTransactionComposer.go
@@ -108,7 +108,7 @@ type AddMethodCallParams struct {
 	// The zero address means the sender.
 	Holdings []types.AppHoldingRef
 	// The local states to be accessed by this method call.
-	// An empty address means the sender.
+	// The zero address means the sender.
 	Locals []types.AppLocalsRef
 }
 

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -1218,6 +1218,8 @@ func MakeApplicationCallTxWithExtraPages(
 // MakeApplicationCallTxWithBoxes is a helper for the above ApplicationCall
 // transaction constructors. A custom ApplicationCall transaction without Access field may
 // be constructed using this method. (see above for args desc.)
+// A sister function MakeApplicationCallTxWithAccess exists to create an ApplicationCall
+// transaction with Access field instead of Accounts, ForeignApps, ForeignAssets and BoxReferences.
 func MakeApplicationCallTxWithBoxes(
 	appIdx uint64,
 	appArgs [][]byte,

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -778,6 +778,134 @@ func TestMakeApplicationCallTxInvalidBoxes(t *testing.T) {
 	require.Error(t, err, "the app id 10 provided for this box is not in the foreignApps array")
 }
 
+func TestMakeApplicationCallTxWithAccess(t *testing.T) {
+	const fee = 1000
+	const firstRound = 2063137
+	const genesisID = "devnet-v1.0"
+	genesisHash := byteFromBase64("sC3P7e2SdbqKJK0tbiCdK9tdSpbe6XeCGKdoNzmlj0E=")
+
+	params := types.SuggestedParams{
+		Fee:             fee,
+		FirstRoundValid: firstRound,
+		LastRoundValid:  firstRound + 1000,
+		GenesisHash:     genesisHash,
+		GenesisID:       genesisID,
+		FlatFee:         true,
+	}
+	note := byteFromBase64("8xMCTuLQ810=")
+	program := []byte{1, 32, 1, 1, 34}
+	gSchema := types.StateSchema{NumUint: uint64(1), NumByteSlice: uint64(1)}
+	lSchema := types.StateSchema{NumUint: uint64(1), NumByteSlice: uint64(1)}
+
+	accounts := []string{"47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU", "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"}
+	addrs, err := parseTxnAccounts(accounts)
+	require.NoError(t, err)
+
+	tx, err := MakeApplicationCallTxWithAccess(111, nil, accounts, nil, nil, nil, nil, nil, types.NoOpOC, program, program, gSchema, lSchema, 0, params, types.Address{}, note, types.Digest{}, [32]byte{}, types.Address{})
+	require.NoError(t, err)
+	require.Nil(t, tx.Accounts)
+	require.Equal(t, []types.ResourceRef{
+		{Address: addrs[0]}, {Address: addrs[1]},
+	}, tx.Access)
+
+	foreignAssets := []uint64{2222, 3333}
+	tx, err = MakeApplicationCallTxWithAccess(111, nil, accounts, nil, foreignAssets, nil, nil, nil, types.NoOpOC, program, program, gSchema, lSchema, 0, params, types.Address{}, note, types.Digest{}, [32]byte{}, types.Address{})
+	require.NoError(t, err)
+	require.Nil(t, tx.ForeignAssets)
+	require.Equal(t, []types.ResourceRef{
+		{Address: addrs[0]}, {Address: addrs[1]},
+		{Asset: types.AssetIndex(foreignAssets[0])}, {Asset: types.AssetIndex(foreignAssets[1])},
+	}, tx.Access)
+
+	foreignApps := []uint64{222, 333}
+	tx, err = MakeApplicationCallTxWithAccess(111, nil, accounts, foreignApps, foreignAssets, nil, nil, nil, types.NoOpOC, program, program, gSchema, lSchema, 0, params, types.Address{}, note, types.Digest{}, [32]byte{}, types.Address{})
+	require.NoError(t, err)
+	require.Nil(t, tx.ForeignApps)
+	require.Equal(t, []types.ResourceRef{
+		{Address: addrs[0]}, {Address: addrs[1]},
+		{Asset: types.AssetIndex(foreignAssets[0])}, {Asset: types.AssetIndex(foreignAssets[1])},
+		{App: types.AppIndex(foreignApps[0])}, {App: types.AppIndex(foreignApps[1])},
+	}, tx.Access)
+
+	appBoxReferences := []types.AppBoxReference{{AppID: 3, Name: []byte("aaa")}}
+	tx, err = MakeApplicationCallTxWithAccess(111, nil, accounts, foreignApps, foreignAssets, appBoxReferences, nil, nil, types.NoOpOC, program, program, gSchema, lSchema, 0, params, types.Address{}, note, types.Digest{}, [32]byte{}, types.Address{})
+	require.NoError(t, err)
+	require.Nil(t, tx.ForeignApps)
+	require.Nil(t, tx.BoxReferences)
+	require.Equal(t, []types.ResourceRef{
+		{Address: addrs[0]}, {Address: addrs[1]},
+		{Asset: types.AssetIndex(foreignAssets[0])}, {Asset: types.AssetIndex(foreignAssets[1])},
+		{App: types.AppIndex(foreignApps[0])}, {App: types.AppIndex(foreignApps[1])},
+
+		{App: 3}, {Box: types.BoxReference{ForeignAppIdx: 7, Name: []byte("aaa")}},
+	}, tx.Access)
+
+	appBoxReferences = []types.AppBoxReference{{AppID: 3, Name: []byte("aaa")}, {AppID: 0, Name: []byte("bbb")}, {AppID: 111, Name: []byte("bbb2")}}
+	tx, err = MakeApplicationCallTxWithAccess(111, nil, accounts, foreignApps, foreignAssets, appBoxReferences, nil, nil, types.NoOpOC, program, program, gSchema, lSchema, 0, params, types.Address{}, note, types.Digest{}, [32]byte{}, types.Address{})
+	require.NoError(t, err)
+	require.Nil(t, tx.ForeignApps)
+	require.Nil(t, tx.BoxReferences)
+	require.Equal(t, []types.ResourceRef{
+		{Address: addrs[0]}, {Address: addrs[1]},
+		{Asset: types.AssetIndex(foreignAssets[0])}, {Asset: types.AssetIndex(foreignAssets[1])},
+		{App: types.AppIndex(foreignApps[0])}, {App: types.AppIndex(foreignApps[1])},
+
+		{App: 3}, {Box: types.BoxReference{ForeignAppIdx: 7, Name: []byte("aaa")}},
+		{Box: types.BoxReference{ForeignAppIdx: 0, Name: []byte("bbb")}},
+		{Box: types.BoxReference{ForeignAppIdx: 0, Name: []byte("bbb2")}},
+	}, tx.Access)
+
+	zero := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ"
+	one := "AEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKE3PRHE"
+	oneAddr, err := types.DecodeAddress(one)
+	require.NoError(t, err)
+	two := "AIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGFFWAF4"
+	twoAddr, err := types.DecodeAddress(two)
+	require.NoError(t, err)
+	holdings := []types.AppHoldingRef{{Asset: 111, Address: one}, {Asset: 3333, Address: zero}}
+	tx, err = MakeApplicationCallTxWithAccess(111, nil, accounts, foreignApps, foreignAssets, appBoxReferences, holdings, nil, types.NoOpOC, program, program, gSchema, lSchema, 0, params, types.Address{}, note, types.Digest{}, [32]byte{}, types.Address{})
+	require.NoError(t, err)
+	require.Nil(t, tx.Accounts)
+	require.Nil(t, tx.ForeignAssets)
+	require.Equal(t, []types.ResourceRef{
+		{Address: addrs[0]}, {Address: addrs[1]},
+		{Asset: types.AssetIndex(foreignAssets[0])}, {Asset: types.AssetIndex(foreignAssets[1])},
+		{App: types.AppIndex(foreignApps[0])}, {App: types.AppIndex(foreignApps[1])},
+
+		{Address: oneAddr}, {Asset: 111}, {Holding: types.HoldingRef{Asset: 8, Address: 7}},
+		{Holding: types.HoldingRef{Asset: 4, Address: 0}},
+
+		{App: 3}, {Box: types.BoxReference{ForeignAppIdx: 11, Name: []byte("aaa")}},
+		{Box: types.BoxReference{ForeignAppIdx: 0, Name: []byte("bbb")}},
+		{Box: types.BoxReference{ForeignAppIdx: 0, Name: []byte("bbb2")}},
+	}, tx.Access)
+
+	locals := []types.AppLocalsRef{{App: 111, Address: two}, {App: 333, Address: zero}, {App: 444, Address: one}}
+	tx, err = MakeApplicationCallTxWithAccess(111, nil, accounts, foreignApps, foreignAssets, appBoxReferences, holdings, locals, types.NoOpOC, program, program, gSchema, lSchema, 0, params, types.Address{}, note, types.Digest{}, [32]byte{}, types.Address{})
+	require.NoError(t, err)
+	require.Nil(t, tx.Accounts)
+	require.Nil(t, tx.ForeignApps)
+	require.Equal(t, []types.ResourceRef{
+		{Address: addrs[0]}, {Address: addrs[1]},
+		{Asset: types.AssetIndex(foreignAssets[0])}, {Asset: types.AssetIndex(foreignAssets[1])},
+		{App: types.AppIndex(foreignApps[0])}, {App: types.AppIndex(foreignApps[1])},
+
+		{Address: oneAddr}, {Asset: 111}, {Holding: types.HoldingRef{Asset: 8, Address: 7}},
+		{Holding: types.HoldingRef{Asset: 4, Address: 0}},
+
+		{Address: twoAddr},
+		{Locals: types.LocalsRef{App: 0, Address: 11}},
+		{Locals: types.LocalsRef{App: 6, Address: 0}},
+		{App: 444},
+		{Locals: types.LocalsRef{App: 14, Address: 7}},
+
+		{App: 3}, {Box: types.BoxReference{ForeignAppIdx: 16, Name: []byte("aaa")}},
+		{Box: types.BoxReference{ForeignAppIdx: 0, Name: []byte("bbb")}},
+		{Box: types.BoxReference{ForeignAppIdx: 0, Name: []byte("bbb2")}},
+	}, tx.Access)
+
+}
+
 func TestComputeGroupID(t *testing.T) {
 	// compare regular transactions created in SDK with 'goal clerk send' result
 	// compare transaction group created in SDK with 'goal clerk group' result

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -855,7 +855,7 @@ func TestMakeApplicationCallTxWithAccess(t *testing.T) {
 		{Box: types.BoxReference{ForeignAppIdx: 0, Name: []byte("bbb2")}},
 	}, tx.Access)
 
-	zero := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ"
+	zero := "" // zero address, the sender => expect index 0 in holdings and locals access entries
 	one := "AEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKE3PRHE"
 	oneAddr, err := types.DecodeAddress(one)
 	require.NoError(t, err)

--- a/types/applications.go
+++ b/types/applications.go
@@ -21,6 +21,22 @@ type AppBoxReference struct {
 	Name []byte
 }
 
+// AppHoldingRef identifies an asset holding by the asset id and the address.
+// It can be viewed as the "hydrated" form of a HoldingRef, which uses indices
+// and typed addresses.
+type AppHoldingRef struct {
+	Asset   uint64
+	Address string
+}
+
+// AppLocalsRef identifies local state by the app id and the address.
+// It can be viewed as the "hydrated" form of a LocalsRef, which uses indices
+// and typed addresses.
+type AppLocalsRef struct {
+	App     uint64
+	Address string
+}
+
 // BoxReference names a box by the index in the foreign app array
 type BoxReference struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`

--- a/types/applications.go
+++ b/types/applications.go
@@ -21,20 +21,18 @@ type AppBoxReference struct {
 	Name []byte
 }
 
-// AppHoldingRef identifies an asset holding by the asset id and the address.
-// It can be viewed as the "hydrated" form of a HoldingRef, which uses indices
-// and typed addresses.
+// AppHoldingRef identifies an asset holding by the asset id and the address (zero address/empty string means Sender).
+// It can be viewed as the "hydrated" form of a HoldingRef, which uses indices.
 type AppHoldingRef struct {
 	Asset   uint64
-	Address string
+	Address string // empty string means Sender
 }
 
-// AppLocalsRef identifies local state by the app id and the address.
-// It can be viewed as the "hydrated" form of a LocalsRef, which uses indices
-// and typed addresses.
+// AppLocalsRef identifies local state by the app id and the address (zero address/empty string means Sender).
+// It can be viewed as the "hydrated" form of a LocalsRef, which uses indices.
 type AppLocalsRef struct {
 	App     uint64
-	Address string
+	Address string // empty string means Sender
 }
 
 // BoxReference names a box by the index in the foreign app array


### PR DESCRIPTION
Added transaction.Access construction method and tests.

The test is inspired by [TestAccessResolution](https://github.com/algorand/go-algorand/blob/be17b0e81d5f46bc5d95b586b6b07751acd4eaed/libgoal/libgoal_test.go#L242)
and the constructor function by [attachAccessList](https://github.com/algorand/go-algorand/blob/be17b0e81d5f46bc5d95b586b6b07751acd4eaed/libgoal/transactions.go#L609)

Added `transaction.Access` to `AtomicTransactionComposer.AddMethodCall`: if `UseAccess` specified it attempts to use a new `MakeApplicationCallTxWithAccess` constructor. If there are reference ABI types and `UseAccess` set then it errs.