### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/client/v2/common/common_test.go
+++ b/client/v2/common/common_test.go
@@ -62,7 +62,6 @@ func TestClient_Verbs(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.expectedVerb, func(t *testing.T) {
 			var receivedMethod string
 			var receivedPath string

--- a/types/address_test.go
+++ b/types/address_test.go
@@ -71,7 +71,6 @@ func TestUnmarshalAddress(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			// wrap in quotes so that it is valid JSON

--- a/types/blockhash_test.go
+++ b/types/blockhash_test.go
@@ -44,7 +44,6 @@ func TestUnmarshalBlockHash(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			// wrap in quotes so that it is valid JSON


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore