### PR TITLE
Types: sync SDK types for on chain congestion PR

### DIFF
--- a/protocol/config/consensus.go
+++ b/protocol/config/consensus.go
@@ -84,11 +84,6 @@ type ConsensusParams struct {
 	// a way of making the spender subsidize the cost of storing this transaction.
 	MinTxnFee uint64
 
-	// EnableFeePooling specifies that the sum of the fees in a
-	// group must exceed one MinTxnFee per Txn, rather than check that
-	// each Txn has a MinFee.
-	EnableFeePooling bool
-
 	// EnableAppCostPooling specifies that the sum of fees for application calls
 	// in a group is checked against the sum of the budget for application calls,
 	// rather than check each individual app call is within the budget.
@@ -565,6 +560,10 @@ type ConsensusParams struct {
 	// legal transactions, this parameter can be removed and assumed true after
 	// the first consensus release in which it is set true.
 	AppSizeUpdates bool
+
+	// CongestionTracking enables header values that track Load and a running
+	// CongestionTax that grows/shrinks when blocks are more/less than half full
+	CongestionTracking bool
 }
 
 // ProposerPayoutRules puts several related consensus parameters in one place. The same
@@ -1093,7 +1092,6 @@ func initConsensusProtocols() {
 	// "reachability" between accounts and creatables, so we
 	// retain 4 x 4 as worst case.
 
-	v28.EnableFeePooling = true
 	v28.EnableKeyregCoherencyCheck = true
 
 	Consensus[protocol.ConsensusV28] = v28
@@ -1373,8 +1371,8 @@ func initConsensusProtocols() {
 	vFuture.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 
 	vFuture.LogicSigVersion = 13 // When moving this to a release, put a new higher LogicSigVersion here
-
 	vFuture.AppSizeUpdates = true
+	vFuture.CongestionTracking = true
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 

--- a/types/block.go
+++ b/types/block.go
@@ -114,6 +114,16 @@ type BlockHeader struct {
 	// ParticipationUpdates contains the information needed to mark
 	// certain accounts offline because their participation keys expired
 	ParticipationUpdates
+
+	// Load is the degree to which a block is full. Currently, it is based on
+	// the number of bytes in the final block, compared to the maximum allowed.
+	// It is expressed as a fixed-point integer with 6 digits of precision.  So,
+	// 1,000,000 is a completely full block.
+	Load Micros `codec:"ld"`
+
+	// CongestionTax fee required, beyond the MinFee, for "normal"
+	// transactions in this block.
+	CongestionTax Micros `codec:"ct"`
 }
 
 // TxnCommitments represents the commitments computed from the transactions in the block.

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -124,13 +124,24 @@ type AssetFreezeTxnFields struct {
 type Header struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	Sender      Address    `codec:"snd"`
-	Fee         MicroAlgos `codec:"fee"`
-	FirstValid  Round      `codec:"fv"`
-	LastValid   Round      `codec:"lv"`
-	Note        []byte     `codec:"note"` // Uniqueness or app-level data about txn
-	GenesisID   string     `codec:"gen"`
-	GenesisHash Digest     `codec:"gh"`
+	Sender Address `codec:"snd"`
+
+	Fee MicroAlgos `codec:"fee"`
+	// Tip represents a multiplier for all costs in the same group. Only one
+	// transaction per group may specify a tip. The Tip does not multiply the
+	// Fee, rather it promises that, with the tip applied, the Fees specified
+	// will still be sufficient.  When congested, `algod` will begin to drop
+	// groups with insifficient tips to cover the block's CongestionTax. Future
+	// versions may prioritize groups with larger tips.
+	Tip Micros `codec:"tp"` // All costs are multiplied by 1 + Tip
+
+	FirstValid Round `codec:"fv"`
+	LastValid  Round `codec:"lv"`
+
+	Note []byte `codec:"note"` // Uniqueness or app-level data about txn
+
+	GenesisID   string `codec:"gen"`
+	GenesisHash Digest `codec:"gh"`
 
 	// Group specifies that this transaction is part of a
 	// transaction group (and, if so, specifies the hash


### PR DESCRIPTION
There will be conflicts with other changes until they are merged, but these changes sync up with the go-algorand PR to do on-chain congestion.