### PR TITLE
TxnSubmit: Annotate API returned errors with Data field of response

### DIFF
--- a/client/v2/common/common.go
+++ b/client/v2/common/common.go
@@ -3,6 +3,7 @@ package common
 import (
 	"bytes"
 	"context"
+	stdjson "encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -78,11 +79,6 @@ func MakeClientWithTransport(address string, apiHeader, apiToken string, headers
 	return
 }
 
-type BadRequest error
-type InvalidToken error
-type NotFound error
-type InternalError error
-
 // extractError checks if the response signifies an error.
 // If so, it returns the error.
 // Otherwise, it returns nil.
@@ -91,18 +87,30 @@ func extractError(code int, errorBuf []byte) error {
 		return nil
 	}
 
-	wrappedError := fmt.Errorf("HTTP %v: %s", code, errorBuf)
+	httpError := &HTTPError{
+		StatusCode: code,
+		RawBody:    errorBuf,
+	}
+	var response struct {
+		Message string         `json:"message"`
+		Data    map[string]any `json:"data,omitempty"`
+	}
+	if err := stdjson.Unmarshal(errorBuf, &response); err == nil {
+		httpError.Message = response.Message
+		httpError.Data = response.Data
+	}
+
 	switch code {
 	case 400:
-		return BadRequest(wrappedError)
+		return BadRequest{HTTPError: httpError}
 	case 401:
-		return InvalidToken(wrappedError)
+		return InvalidToken{HTTPError: httpError}
 	case 404:
-		return NotFound(wrappedError)
+		return NotFound{HTTPError: httpError}
 	case 500:
-		return InternalError(wrappedError)
+		return InternalError{HTTPError: httpError}
 	default:
-		return wrappedError
+		return httpError
 	}
 }
 

--- a/client/v2/common/common_test.go
+++ b/client/v2/common/common_test.go
@@ -2,7 +2,7 @@ package common
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,23 +14,69 @@ import (
 
 func TestExtractError(t *testing.T) {
 	testcases := []struct {
-		name string
-		code int
-		err  error
+		name    string
+		code    int
+		wantErr string
 	}{
-		{name: "400", code: 400, err: BadRequest(fmt.Errorf("HTTP 400: "))},
-		{name: "401", code: 401, err: InvalidToken(fmt.Errorf("HTTP 401: "))},
-		{name: "404", code: 404, err: NotFound(fmt.Errorf("HTTP 404: "))},
-		{name: "500", code: 500, err: InternalError(fmt.Errorf("HTTP 500: "))},
-		{name: "200", code: 200, err: nil},
-		{name: "201", code: 201, err: nil},
+		{name: "400", code: 400, wantErr: "HTTP 400: "},
+		{name: "401", code: 401, wantErr: "HTTP 401: "},
+		{name: "404", code: 404, wantErr: "HTTP 404: "},
+		{name: "500", code: 500, wantErr: "HTTP 500: "},
+		{name: "200", code: 200},
+		{name: "201", code: 201},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.err, extractError(tc.code, []byte{}))
+			err := extractError(tc.code, []byte{})
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, tc.wantErr)
+
+			switch tc.code {
+			case 400:
+				assert.IsType(t, BadRequest{}, err)
+			case 401:
+				assert.IsType(t, InvalidToken{}, err)
+			case 404:
+				assert.IsType(t, NotFound{}, err)
+			case 500:
+				assert.IsType(t, InternalError{}, err)
+			}
 		})
 	}
+}
+
+func TestExtractErrorIncludesRESTData(t *testing.T) {
+	err := extractError(400, []byte(`{"message":"txn dead","data":{"pool-error":"logic eval error","pc":7}}`))
+	require.Error(t, err)
+	require.EqualError(t, err, `HTTP 400: txn dead`)
+
+	var httpErr *HTTPError
+	require.True(t, errors.As(err, &httpErr))
+	require.NotNil(t, httpErr)
+	assert.Equal(t, 400, httpErr.StatusCode)
+	assert.Equal(t, "txn dead", httpErr.Message)
+
+	data := httpErr.Data
+	require.NotNil(t, data)
+	assert.Equal(t, "logic eval error", data["pool-error"])
+	assert.Equal(t, float64(7), data["pc"])
+}
+
+func TestExtractErrorIgnoresInvalidJSON(t *testing.T) {
+	err := extractError(400, []byte("not json"))
+	require.Error(t, err)
+	require.EqualError(t, err, "HTTP 400: not json")
+
+	var httpErr *HTTPError
+	require.True(t, errors.As(err, &httpErr))
+	require.NotNil(t, httpErr)
+	assert.Empty(t, httpErr.Message)
+	assert.Nil(t, httpErr.Data)
+	assert.Equal(t, []byte("not json"), httpErr.RawBody)
 }
 
 func TestClient_Verbs(t *testing.T) {

--- a/client/v2/common/http_error.go
+++ b/client/v2/common/http_error.go
@@ -1,0 +1,54 @@
+package common
+
+import "fmt"
+
+// HTTPError contains the raw HTTP error body plus parsed REST error fields when available.
+type HTTPError struct {
+	StatusCode int
+	Message    string
+	Data       map[string]any
+	RawBody    []byte
+}
+
+func (e *HTTPError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.RawBody)
+}
+
+// BadRequest represents a 400 HTTP response.
+type BadRequest struct {
+	*HTTPError
+}
+
+func (e BadRequest) Unwrap() error {
+	return e.HTTPError
+}
+
+// InvalidToken represents a 401 HTTP response.
+type InvalidToken struct {
+	*HTTPError
+}
+
+func (e InvalidToken) Unwrap() error {
+	return e.HTTPError
+}
+
+// NotFound represents a 404 HTTP response.
+type NotFound struct {
+	*HTTPError
+}
+
+func (e NotFound) Unwrap() error {
+	return e.HTTPError
+}
+
+// InternalError represents a 500 HTTP response.
+type InternalError struct {
+	*HTTPError
+}
+
+func (e InternalError) Unwrap() error {
+	return e.HTTPError
+}

--- a/test/applications_integration_test.go
+++ b/test/applications_integration_test.go
@@ -9,24 +9,27 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
-
-	"github.com/algorand/go-algorand-sdk/v2/transaction"
-
-	"github.com/cucumber/godog"
 
 	"github.com/algorand/go-algorand-sdk/v2/abi"
 	"github.com/algorand/go-algorand-sdk/v2/client/v2/algod"
+	"github.com/algorand/go-algorand-sdk/v2/client/v2/common"
 	"github.com/algorand/go-algorand-sdk/v2/client/v2/common/models"
 	"github.com/algorand/go-algorand-sdk/v2/client/v2/indexer"
 	"github.com/algorand/go-algorand-sdk/v2/crypto"
 	sdkJson "github.com/algorand/go-algorand-sdk/v2/encoding/json"
+	"github.com/algorand/go-algorand-sdk/v2/transaction"
 	"github.com/algorand/go-algorand-sdk/v2/types"
+	"github.com/cucumber/godog"
+	"github.com/stretchr/testify/require"
 )
 
 var algodV2client *algod.Client
@@ -240,12 +243,53 @@ func iSignAndSubmitTheTransactionSavingTheTxidIfThereIsAnErrorItIs(expectedErr s
 		return err
 	}
 	txid, err = algodV2client.SendRawTransaction(lstx).Do(context.Background())
-	if err != nil && len(expectedErr) != 0 {
-		if strings.Contains(err.Error(), expectedErr) {
+	return checkSubmitTransactionError(err, expectedErr, "", "")
+}
+
+func iSignAndSubmitTheTransactionSavingTheTxidIfThereIsAnErrorItIsAndTheDataContains(expectedErr, dataKey, dataValue string) error {
+	var err error
+	var lstx []byte
+
+	txid, lstx, err = crypto.SignTransaction(transientAccount.PrivateKey, tx)
+	if err != nil {
+		return err
+	}
+	txid, err = algodV2client.SendRawTransaction(lstx).Do(context.Background())
+	return checkSubmitTransactionError(err, expectedErr, dataKey, dataValue)
+}
+
+func checkSubmitTransactionError(err error, expectedErr, dataKey, dataValue string) error {
+	if err == nil {
+		if expectedErr == "" && dataKey == "" {
 			return nil
 		}
+		return fmt.Errorf("expected an error but transaction submission succeeded")
 	}
-	return err
+
+	if expectedErr != "" && !strings.Contains(err.Error(), expectedErr) {
+		return err
+	}
+	if dataKey == "" {
+		return nil
+	}
+
+	var httpErr *common.HTTPError
+	if !errors.As(err, &httpErr) {
+		return fmt.Errorf("expected an SDK HTTP error, got %T", err)
+	}
+	if httpErr.Data == nil {
+		return fmt.Errorf("expected structured error data on HTTP error")
+	}
+
+	actualValue, ok := httpErr.Data[dataKey]
+	if !ok {
+		return fmt.Errorf("expected error data to contain key %q", dataKey)
+	}
+	if fmt.Sprint(actualValue) != dataValue {
+		return fmt.Errorf("expected error data %q to be %q, got %v", dataKey, dataValue, actualValue)
+	}
+
+	return nil
 }
 
 func iWaitForTheTransactionToBeConfirmed() error {
@@ -1022,6 +1066,7 @@ func ApplicationsContext(s *godog.ScenarioContext) {
 	s.Step(`^I create a new transient account and fund it with (\d+) microalgos\.$`, iCreateANewTransientAccountAndFundItWithMicroalgos)
 	s.Step(`^I build an application transaction with the transient account, the current application, suggested params, operation "([^"]*)", approval-program "([^"]*)", clear-program "([^"]*)", global-bytes (\d+), global-ints (\d+), local-bytes (\d+), local-ints (\d+), app-args "([^"]*)", foreign-apps "([^"]*)", foreign-assets "([^"]*)", app-accounts "([^"]*)", extra-pages (\d+), boxes "([^"]*)"$`, iBuildAnApplicationTransaction)
 	s.Step(`^I sign and submit the transaction, saving the txid\. If there is an error it is "([^"]*)"\.$`, iSignAndSubmitTheTransactionSavingTheTxidIfThereIsAnErrorItIs)
+	s.Step(`^I sign and submit the transaction, saving the txid\. If there is an error it is "([^"]*)" and the data contains "([^"]*)" = "([^"]*)"\.$`, iSignAndSubmitTheTransactionSavingTheTxidIfThereIsAnErrorItIsAndTheDataContains)
 	s.Step(`^I wait for the transaction to be confirmed\.$`, iWaitForTheTransactionToBeConfirmed)
 	s.Step(`^I remember the new application ID\.$`, iRememberTheNewApplicationID)
 	s.Step(`^I reset the array of application IDs to remember\.$`, iResetTheArrayOfApplicationIDsToRemember)
@@ -1050,4 +1095,52 @@ func ApplicationsContext(s *godog.ScenarioContext) {
 	s.Step(`^according to "([^"]*)", with (\d+) being the parameter that limits results, the current application should have (\d+) boxes\.$`, currentApplicationShouldHaveBoxNum)
 	s.Step(`^according to indexer, with (\d+) being the parameter that limits results, and "([^"]*)" being the parameter that sets the next result, the current application should have the following boxes "([^"]*)"\.$`, indexerSaysCurrentAppShouldHaveTheseBoxes)
 	s.Step(`^I wait for indexer to catch up to the round where my most recent transaction was confirmed\.$`, waitForIndexerToCatchUp)
+}
+
+func TestSubmitAppCallTransactionErrorIncludesData(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v2/transactions", r.URL.Path)
+		w.WriteHeader(http.StatusBadRequest)
+		_, err := w.Write([]byte(`{"message":"transaction rejected","data":{"pool-error":"logic eval error","pc":7}}`))
+		require.NoError(t, err)
+	}))
+	defer mockServer.Close()
+
+	algodClient, err := algod.MakeClient(mockServer.URL, "")
+	require.NoError(t, err)
+
+	account := crypto.GenerateAccount()
+	params := types.SuggestedParams{
+		Fee:             1000,
+		FirstRoundValid: 1,
+		LastRoundValid:  1000,
+		GenesisID:       "testnet-v1.0",
+		GenesisHash:     []byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+	}
+	appCallTxn, err := transaction.MakeApplicationNoOpTx(
+		1,
+		nil,
+		nil,
+		nil,
+		nil,
+		params,
+		account.Address,
+		nil,
+		types.Digest{},
+		[32]byte{},
+		types.Address{},
+	)
+	require.NoError(t, err)
+
+	_, signedTxn, err := crypto.SignTransaction(account.PrivateKey, appCallTxn)
+	require.NoError(t, err)
+
+	_, err = algodClient.SendRawTransaction(signedTxn).Do(context.Background())
+	require.Error(t, err)
+	require.NoError(t, checkSubmitTransactionError(err, "transaction rejected", "pool-error", "logic eval error"))
+
+	var httpErr *common.HTTPError
+	require.True(t, errors.As(err, &httpErr))
+	require.Equal(t, float64(7), httpErr.Data["pc"])
 }


### PR DESCRIPTION
This should expose the extra data returned when a submitted transaction fails.