### PR TITLE
types: sync consensus params

### DIFF
--- a/protocol/config/consensus.go
+++ b/protocol/config/consensus.go
@@ -101,10 +101,6 @@ type ConsensusParams struct {
 	// group. The total available is len(group) * LogicSigMaxCost
 	EnableLogicSigCostPooling bool
 
-	// EnableLogicSigSizePooling specifies LogicSig sizes are pooled across a
-	// group. The total available is len(group) * LogicSigMaxSize
-	EnableLogicSigSizePooling bool
-
 	// RewardUnit specifies the number of MicroAlgos corresponding to one reward
 	// unit.
 	//
@@ -217,8 +213,14 @@ type ConsensusParams struct {
 	// 0 for no support, otherwise highest version supported
 	LogicSigVersion uint64
 
-	// len(LogicSig.Logic) + len(LogicSig.Args[*]) must be less than this (unless pooling is enabled)
+	// LogicSigMaxSize is the legacy LogicSig size unit used for the per-LogicSig
+	// args allowance and to compute group size pools and free program-byte
+	// allowance.
 	LogicSigMaxSize uint64
+
+	// MaxAbsoluteLogicSigProgramSize is the absolute maximum size of a LogicSig
+	// program.
+	MaxAbsoluteLogicSigProgramSize uint64
 
 	// sum of estimated op cost must be less than this
 	LogicSigMaxCost uint64
@@ -917,6 +919,7 @@ func initConsensusProtocols() {
 	v18.Asset = true
 	v18.LogicSigVersion = 1
 	v18.LogicSigMaxSize = 1000
+	v18.MaxAbsoluteLogicSigProgramSize = 1000
 	v18.LogicSigMaxCost = 20000
 	v18.LogicSigMsig = true
 	v18.MaxAssetsPerAccount = 1000
@@ -1338,8 +1341,7 @@ func initConsensusProtocols() {
 	v40.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 
 	v40.LogicSigVersion = 11
-
-	v40.EnableLogicSigSizePooling = true
+	v40.MaxAbsoluteLogicSigProgramSize = 16000
 
 	v40.Payouts.Enabled = true
 	v40.Payouts.Percent = 50

--- a/types/statedelta.go
+++ b/types/statedelta.go
@@ -63,6 +63,11 @@ type AppParams struct {
 	// SizeSponsor, if non-zero, is the account that must hold MBR for
 	// extra program pages, and the global schema.
 	SizeSponsor Address `codec:"ss"`
+
+	// ForeignBoxReads, when true, allows any app to read this app's boxes.
+	ForeignBoxReads bool `codec:"fbr"`
+	// FamilyBoxAccess, when true, allows apps with the same creator to read and write this app's boxes.
+	FamilyBoxAccess bool `codec:"fba"`
 }
 
 // AppLocalState stores the LocalState associated with an application. It also

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -246,9 +246,13 @@ type PQScheme [2]byte
 // address derivation.
 type PQAddressSalt uint8
 
-// PQSig is a post-quantum transaction authorization proof.
+// PQSig is a post-quantum transaction authorization proof. Its public key and
+// signature are wire/decode-bounded by crypto.MaxPQPublicKeySize and
+// crypto.MaxPQSignatureSize (the largest sizes over all supported PQ schemes),
+// which feed msgp allocation bounds and therefore PQSigMaxSize, SignedTxnMaxSize,
+// and the SignedTxn wire bound.
 type PQSig struct {
-	_struct struct{} `codec:",omitempty"`
+	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
 	Scheme    PQScheme      `codec:"sch"`
 	Salt      PQAddressSalt `codec:"slt"`


### PR DESCRIPTION
Rerun `python3 scripts/export_sdk_types.py` on current go-algorand master