### PR TITLE
protocol: add fnet1..4 consensus versions

### DIFF
--- a/protocol/config/consensus.go
+++ b/protocol/config/consensus.go
@@ -1438,6 +1438,46 @@ func initConsensusProtocols() {
 	vAlpha5.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 	Consensus[protocol.ConsensusVAlpha5] = vAlpha5
 	vAlpha4.ApprovedUpgrades[protocol.ConsensusVAlpha5] = 10000
+
+	// vFnetX are like vAlphaX but for AF's FNet. These are the genesis and
+	// historical protocols for the FNet network. The on-chain upgrade path was
+	// fnet1->fnet2->fnet3->fnet4->V40.
+	vFnet1 := v39
+	vFnet1.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	vFnet1.LogicSigVersion = 11 // When moving this to a release, put a new higher LogicSigVersion here
+	vFnet1.Payouts.Enabled = true
+	vFnet1.Payouts.Percent = 75
+	vFnet1.Payouts.GoOnlineFee = 2_000_000         // 2 algos
+	vFnet1.Payouts.MinBalance = 30_000_000_000     // 30,000 algos
+	vFnet1.Payouts.MaxBalance = 70_000_000_000_000 // 70M algos
+	vFnet1.Payouts.MaxMarkAbsent = 32
+	vFnet1.Payouts.ChallengeInterval = 1000
+	vFnet1.Payouts.ChallengeGracePeriod = 200
+	vFnet1.Payouts.ChallengeBits = 5
+	vFnet1.Bonus.BaseAmount = 10_000_000 // 10 Algos
+	vFnet1.Bonus.DecayInterval = 250_000 // .99^(10.8/0.25) ~ .648. So 35% decay per year
+	Consensus[protocol.ConsensusVFnet1] = vFnet1
+
+	// vFnet2 guards against a future change in block opcodes that the fnet1 client did not support. No change in parameters
+	vFnet2 := vFnet1
+	vFnet2.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	Consensus[protocol.ConsensusVFnet2] = vFnet2
+	vFnet1.ApprovedUpgrades[protocol.ConsensusVFnet2] = 10000
+
+	// vFnet3 disabled challenges - without heartbeats, participating accounts are being evicted
+	vFnet3 := vFnet2
+	vFnet3.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	vFnet3.Payouts.ChallengeInterval = 0
+	Consensus[protocol.ConsensusVFnet3] = vFnet3
+	vFnet2.ApprovedUpgrades[protocol.ConsensusVFnet3] = 10000
+
+	// vFnet4: challenges and heartbeats
+	vFnet4 := vFnet1
+	vFnet4.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	Consensus[protocol.ConsensusVFnet4] = vFnet4
+	vFnet3.ApprovedUpgrades[protocol.ConsensusVFnet4] = 10000
+
+	vFnet4.ApprovedUpgrades[protocol.ConsensusV40] = 10000
 }
 
 // Global defines global Algorand protocol parameters which should not be overridden.

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -234,6 +234,22 @@ const ConsensusVAlpha4 = ConsensusVersion("alpha4")
 // ConsensusVAlpha5 uses the same parameters as ConsensusV36.
 const ConsensusVAlpha5 = ConsensusVersion("alpha5")
 
+// ConsensusVFnet1 is the genesis protocol for AF's FNet, based on ConsensusV39
+// with incentives (payouts/challenges) and TEAL v11 enabled.
+const ConsensusVFnet1 = ConsensusVersion("fnet1")
+
+// ConsensusVFnet2 guards against a block-opcode change the fnet1 client did not
+// support; same parameters as fnet1.
+const ConsensusVFnet2 = ConsensusVersion("fnet2")
+
+// ConsensusVFnet3 disables challenges; without heartbeats, participating
+// accounts were being evicted.
+const ConsensusVFnet3 = ConsensusVersion("fnet3")
+
+// ConsensusVFnet4 re-enables challenges and brings heartbeats; upgrades to
+// ConsensusV40.
+const ConsensusVFnet4 = ConsensusVersion("fnet4")
+
 // !!! ********************* !!!
 // !!! *** Please update ConsensusCurrentVersion when adding new protocol versions *** !!!
 // !!! ********************* !!!


### PR DESCRIPTION
Mirrors the FNet consensus versions in go-algorand ([PR here](https://github.com/algorand/go-algorand/pull/6675)) so the SDK can interpret FNet consensus params. 

Needed for conduit/indexer to work with FNet.

Verified: builds and gofmt-clean; the fnet1..4 params load into the Consensus map with the correct payout/challenge settings and upgrade edges.