### PR TITLE
sync: fnet and enableF128sortition

### DIFF
--- a/protocol/config/consensus.go
+++ b/protocol/config/consensus.go
@@ -589,6 +589,10 @@ type ConsensusParams struct {
 	// EnablePQSchemeFalcon1024 enables native Falcon-1024 transaction
 	// authorization for the f1 PQ scheme.
 	EnablePQSchemeFalcon1024 bool
+
+	// EnableSelectF128 changes the sortition algorithm to use a 128-bit software
+	// floating point binomial CDF implementation for committee selection.
+	EnableSelectF128 bool
 }
 
 // ProposerPayoutRules puts several related consensus parameters in one place. The same
@@ -1405,6 +1409,7 @@ func initConsensusProtocols() {
 	vFuture.MaxAbsoluteExtraProgramPages = 7 // Allow larger programs with extra fees
 	vFuture.MaxAbsoluteTotalArgLen = 16384   // We _could_ make this as high as 16*4k
 	vFuture.PerByteTxnSurcharge = 100        // Each charged byte adds 0.000100 of min fee
+	vFuture.EnableSelectF128 = true
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 
@@ -1438,6 +1443,47 @@ func initConsensusProtocols() {
 	vAlpha5.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 	Consensus[protocol.ConsensusVAlpha5] = vAlpha5
 	vAlpha4.ApprovedUpgrades[protocol.ConsensusVAlpha5] = 10000
+
+	// vFnetX are like vAlphaX but for AF's FNet. These are the genesis and
+	// historical protocols for the FNet network; a mainline node needs them to
+	// open the FNet genesis ledger (proto fnet1) and to replay the pre-V40 chain.
+	// The on-chain upgrade path was fnet1->fnet2->fnet3->fnet4->V40.
+	vFnet1 := v39
+	vFnet1.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	vFnet1.LogicSigVersion = 11 // When moving this to a release, put a new higher LogicSigVersion here
+	vFnet1.Payouts.Enabled = true
+	vFnet1.Payouts.Percent = 75
+	vFnet1.Payouts.GoOnlineFee = 2_000_000         // 2 algos
+	vFnet1.Payouts.MinBalance = 30_000_000_000     // 30,000 algos
+	vFnet1.Payouts.MaxBalance = 70_000_000_000_000 // 70M algos
+	vFnet1.Payouts.MaxMarkAbsent = 32
+	vFnet1.Payouts.ChallengeInterval = 1000
+	vFnet1.Payouts.ChallengeGracePeriod = 200
+	vFnet1.Payouts.ChallengeBits = 5
+	vFnet1.Bonus.BaseAmount = 10_000_000 // 10 Algos
+	vFnet1.Bonus.DecayInterval = 250_000 // .99^(10.8/0.25) ~ .648. So 35% decay per year
+	Consensus[protocol.ConsensusVFnet1] = vFnet1
+
+	// vFnet2 guards against a future change in block opcodes that the fnet1 client did not support. No change in parameters
+	vFnet2 := vFnet1
+	vFnet2.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	Consensus[protocol.ConsensusVFnet2] = vFnet2
+	vFnet1.ApprovedUpgrades[protocol.ConsensusVFnet2] = 10000
+
+	// vFnet3 disabled challenges - without heartbeats, participating accounts are being evicted
+	vFnet3 := vFnet2
+	vFnet3.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	vFnet3.Payouts.ChallengeInterval = 0
+	Consensus[protocol.ConsensusVFnet3] = vFnet3
+	vFnet2.ApprovedUpgrades[protocol.ConsensusVFnet3] = 10000
+
+	// vFnet4: replacing challenges and heartbeats, back to vFnet1 parameters, with a new upgrade path to V40
+	vFnet4 := vFnet1
+	vFnet4.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	Consensus[protocol.ConsensusVFnet4] = vFnet4
+	vFnet3.ApprovedUpgrades[protocol.ConsensusVFnet4] = 10000
+
+	vFnet4.ApprovedUpgrades[protocol.ConsensusV40] = 10000
 }
 
 // Global defines global Algorand protocol parameters which should not be overridden.

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -234,6 +234,22 @@ const ConsensusVAlpha4 = ConsensusVersion("alpha4")
 // ConsensusVAlpha5 uses the same parameters as ConsensusV36.
 const ConsensusVAlpha5 = ConsensusVersion("alpha5")
 
+// ConsensusVFnet1 is the genesis protocol for AF's FNet, based on ConsensusV39
+// with incentives (payouts/challenges) and TEAL v11 enabled.
+const ConsensusVFnet1 = ConsensusVersion("fnet1")
+
+// ConsensusVFnet2 guards against a block-opcode change the fnet1 client did not
+// support; same parameters as fnet1.
+const ConsensusVFnet2 = ConsensusVersion("fnet2")
+
+// ConsensusVFnet3 disables challenges; without heartbeats, participating
+// accounts were being evicted.
+const ConsensusVFnet3 = ConsensusVersion("fnet3")
+
+// ConsensusVFnet4 re-enables challenges and brings heartbeats; upgrades to
+// ConsensusV40.
+const ConsensusVFnet4 = ConsensusVersion("fnet4")
+
 // !!! ********************* !!!
 // !!! *** Please update ConsensusCurrentVersion when adding new protocol versions *** !!!
 // !!! ********************* !!!

--- a/types/heartbeat.go
+++ b/types/heartbeat.go
@@ -6,7 +6,7 @@ package types
 type HeartbeatTxnFields struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	// HeartbeatAddress is the account this txn is proving onlineness for.
+	// HbAddress is the account this txn is proving onlineness for.
 	HbAddress Address `codec:"a"`
 
 	// HbProof is a signature using HeartbeatAddress's partkey, thereby showing it is online.
@@ -15,13 +15,25 @@ type HeartbeatTxnFields struct {
 	// The final three fields are included to allow early, concurrent check of
 	// the HbProof.
 
-	// HbSeed must be the block seed for this transaction's firstValid
-	// block. It is the message that must be signed with HbAddress's part key.
+	// HbSeed must be the block seed for this transaction's firstValid block. It
+	// is the message that must be signed with HbAddress's part key.
 	HbSeed Seed `codec:"sd"`
 
 	// HbVoteID must match the HbAddress account's current VoteID.
-	HbVoteID OneTimeSignatureVerifier `codec:"vid"`
+	HbVoteID VotePK `codec:"vid"`
 
 	// HbKeyDilution must match HbAddress account's current KeyDilution.
 	HbKeyDilution uint64 `codec:"kd"`
+
+	// HbChallengeDiscount requests the challenge fee discount: when set, the
+	// required fee is reduced by one min fee. It is optional even for a
+	// challenged account (an account willing to pay the normal fee can leave it
+	// off), so it is a request, not an assertion. apply verifies HbAddress is
+	// actually under challenge before granting it. The flag is only allowed
+	// once transaction size pricing is enabled (proto.TxnSizePricingEnabled());
+	// it makes sense to think in terms of transaction fields changing fees
+	// now, so it needs no separate consensus flag. Before then, the discount
+	// was inferred from an underpaid singleton heartbeat instead (see
+	// wellFormed and apply).
+	HbChallengeDiscount bool `codec:"c"`
 }


### PR DESCRIPTION
This should contain #823, a recent consensus params update, and heartbeat discount field