### PR TITLE
Sync: Update for v42 consensus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # ignore cucumber test resources
 test-harness/
+.staged-sandbox/
 test/features/
 test/features/resources/**/*.json
 test/features/resources/**/*.base64

--- a/.test-env
+++ b/.test-env
@@ -14,3 +14,15 @@ REMOVE_LOCAL_FEATURES=0
 # WARNING: Be careful when turning on the next variable.
 # In that case you'll need to provide all variables expected by `algorand-sdk-testing`'s `.env`
 OVERWRITE_TESTING_ENVIRONMENT=0
+
+# Build the harness's indexer and conduit against this working tree rather than
+# against the go-algorand-sdk release their go.mod files pin. Keep this on: the
+# pinned releases lag this repo, so they reject blocks that a freshly built
+# algod produces whenever a consensus version is in flight. Set to 0 to test
+# against the SDK release that indexer and conduit ship with instead.
+LOCAL_SDK_BUILD=1
+
+# The leading dot keeps the go tool from walking the staged sandbox: it ships
+# `disabled.go` files that would otherwise join this module and break `go list
+# ./...` for every other target.
+STAGED_SANDBOX=".staged-sandbox"

--- a/protocol/config/consensus.go
+++ b/protocol/config/consensus.go
@@ -1394,22 +1394,34 @@ func initConsensusProtocols() {
 	// our current max is 250000
 	v40.ApprovedUpgrades[protocol.ConsensusV41] = 208000
 
+	v42 := v41
+	v42.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+
+	v42.LogicSigVersion = 13
+	v42.AppSizeUpdates = true
+	v42.AllowZeroLocalAppRef = true
+	v42.EnforceAuthAddrSenderDiff = true
+	v42.EnablePQSchemeFalcon1024 = true
+	v42.LoadTracking = true
+	v42.MaxAbsoluteTxnNoteBytes = 4096   // same as largest AVM value
+	v42.MaxAbsoluteExtraProgramPages = 7 // Allow larger programs with extra fees
+	v42.MaxAbsoluteTotalArgLen = 16384   // We _could_ make this as high as 16*4k
+	v42.PerByteTxnSurcharge = 100        // Each charged byte adds 0.000100 of min fee
+	v42.EnableSelectF128 = true
+
+	Consensus[protocol.ConsensusV42] = v42
+
+	// v41 can be upgraded to v42, with an update delay of 7d:
+	// 208000 = (7 * 24 * 60 * 60 / 2.9 ballpark round times)
+	// our current max is 250000
+	v41.ApprovedUpgrades[protocol.ConsensusV42] = 208000
+
 	// ConsensusFuture is used to test features that are implemented
 	// but not yet released in a production protocol version.
-	vFuture := v41
+	vFuture := v42
 	vFuture.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 
-	vFuture.LogicSigVersion = 13 // When moving this to a release, put a new higher LogicSigVersion here
-	vFuture.AppSizeUpdates = true
-	vFuture.AllowZeroLocalAppRef = true
-	vFuture.EnforceAuthAddrSenderDiff = true
-	vFuture.EnablePQSchemeFalcon1024 = true
-	vFuture.LoadTracking = true
-	vFuture.MaxAbsoluteTxnNoteBytes = 4096   // same as largest AVM value
-	vFuture.MaxAbsoluteExtraProgramPages = 7 // Allow larger programs with extra fees
-	vFuture.MaxAbsoluteTotalArgLen = 16384   // We _could_ make this as high as 16*4k
-	vFuture.PerByteTxnSurcharge = 100        // Each charged byte adds 0.000100 of min fee
-	vFuture.EnableSelectF128 = true
+	vFuture.LogicSigVersion = 14 // When moving this to a release, put a new higher LogicSigVersion here
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -211,6 +211,12 @@ const ConsensusV41 = ConsensusVersion(
 	"https://github.com/algorandfoundation/specs/tree/953304de35264fc3ef91bcd05c123242015eeaed",
 )
 
+// ConsensusV42 enables app size updates, Falcon1024 post-quantum signatures,
+// load tracking, a per-byte transaction surcharge, and TEAL v13.
+const ConsensusV42 = ConsensusVersion(
+	"https://github.com/algorandfoundation/specs/tree/268b63433a907455d439995bf916f6b296018f4f",
+)
+
 // ConsensusFuture is a protocol that should not appear in any production
 // network, but is used to test features before they are released.
 const ConsensusFuture = ConsensusVersion(
@@ -256,7 +262,7 @@ const ConsensusVFnet4 = ConsensusVersion("fnet4")
 
 // ConsensusCurrentVersion is the latest version and should be used
 // when a specific version is not provided.
-const ConsensusCurrentVersion = ConsensusV41
+const ConsensusCurrentVersion = ConsensusV42
 
 // Error is used to indicate that an unsupported protocol has been detected.
 type Error ConsensusVersion

--- a/test-harness.sh
+++ b/test-harness.sh
@@ -20,6 +20,9 @@ set -euo pipefail
 #   WARNING: Be careful when turning on the next variable.
 #   In that case you'll need to provide all variables expected by `algorand-sdk-testing`'s `.env`
 #   OVERWRITE_TESTING_ENVIRONMENT=0
+#
+#   LOCAL_SDK_BUILD    - build the harness's indexer and conduit against this working tree.
+#   STAGED_SANDBOX     - local directory that the patched sandbox is staged in.
 
 SHUTDOWN=0
 if [ $# -ne 0 ]; then
@@ -56,6 +59,85 @@ rootdir=$(dirname "$0")
 pushd "$rootdir"
 
 echo "$THIS: VERBOSE_HARNESS=$VERBOSE_HARNESS"
+
+# Read one variable from algorand-sdk-testing's own .env, without letting its
+# settings leak into ours (it defines VERBOSE_HARNESS too, for instance).
+harness_env() {
+  ( set -a; source "$SDK_TESTING_HARNESS"/.env; set +a; printf '%s' "${!1}" )
+}
+
+GO_MOD_REPLACE='go mod edit -replace github.com/algorand/go-algorand-sdk/v2=/tmp/local-sdk'
+
+# Rewrite the line matching $2 as the perl replacement $3, then confirm $4 is in
+# the file. These patches land in files owned by the sandbox repo, so a silent
+# no-op is a real possibility -- and would resurface much later as a baffling
+# failure from deep inside a docker build.
+patch_line() {
+  local file=$1 pattern=$2 replacement=$3 expect=$4
+  perl -0pi -e "s{^$pattern\$}{$replacement}m" "$file"
+  if ! grep -qF "$expect" "$file"; then
+    echo "$THIS: cannot patch $file, no line matches /^$pattern\$/" >&2
+    exit 1
+  fi
+}
+
+# Give one sandbox image the staged SDK and build it against that instead of the
+# release its go.mod pins. A directory replace covers the modules that reach the
+# SDK indirectly too, so patching conduit is enough to also rebuild the indexer
+# packages it embeds. $3 overrides the build command that install.sh runs.
+patch_sandbox_image() {
+  local dir=$1 dockerfile=$2 build=${3:-make}
+  patch_line "$dir/$dockerfile" 'RUN /tmp/install\.sh' \
+    'COPY images/local-sdk /tmp/local-sdk\n$&' 'COPY images/local-sdk'
+  patch_line "$dir/install.sh" 'make' "$GO_MOD_REPLACE\n$build" "$GO_MOD_REPLACE"
+}
+
+# The sandbox builds indexer and conduit by cloning them inside a container, so
+# each compiles against the go-algorand-sdk release its go.mod pins. Whenever
+# this repo adds support for something those releases predate -- a new consensus
+# version, most often -- the pinned builds reject the blocks algod produces and
+# the harness never comes up. Staging our own copy of the sandbox lets both
+# builds compile against this working tree, with no need to publish an SDK
+# branch for them to depend on.
+stage_local_sdk_sandbox() {
+  local url branch sandbox
+  url=$(harness_env SANDBOX_URL)
+  branch=$(harness_env SANDBOX_BRANCH)
+  sandbox="$(pwd)/$STAGED_SANDBOX"
+
+  git clone --depth 1 --single-branch --branch "$branch" "$url" "$sandbox"
+
+  # The sandbox's .dockerignore excludes everything outside a few directories,
+  # so the SDK has to be staged under images/ to reach the build context.
+  rsync -a --exclude .git --exclude "$SDK_TESTING_HARNESS" --exclude "$STAGED_SANDBOX" \
+    ./ "$sandbox"/images/local-sdk
+
+  patch_sandbox_image "$sandbox"/images/indexer IndexerDockerfile
+
+  # Conduit's default make target regenerates its filter-processor field map by
+  # reflecting over the SDK's transaction types, and that generator treats a
+  # codec tag verbatim when it recurses, so an option like `txn,required` throws
+  # off every nested tag path it looks up. It also has no cast for the pqsig
+  # fields. Both leave it rejecting any SDK newer than the release conduit pins.
+  # The file it would rewrite is committed and still compiles, so build the
+  # binary and leave generation out of it.
+  patch_sandbox_image "$sandbox"/images/conduit Dockerfile '(cd cmd/conduit && go build)'
+
+  # up.sh gets at the sandbox by cloning it, which only carries committed state.
+  git -C "$sandbox" add -Af
+  git -C "$sandbox" \
+    -c user.name="$THIS" -c user.email="$THIS@localhost" \
+    commit -qm "build indexer and conduit against the local go-algorand-sdk"
+
+  # up.sh sources .env with `set -a`, so appending overrides the defaults that
+  # algorand-sdk-testing ships with.
+  {
+    echo "SANDBOX_URL=\"file://$sandbox\""
+    echo "SANDBOX_BRANCH=\"$branch\""
+  } >> "$SDK_TESTING_HARNESS"/.env
+}
+
+rm -rf "$STAGED_SANDBOX"
 
 ## Reset test harness
 if [ -d "$SDK_TESTING_HARNESS" ]; then
@@ -103,6 +185,12 @@ echo "$THIS: seconds it took to get to end of cloning and copying: $(($(date "+%
 if [[ $INSTALL_ONLY == 1 ]]; then
   echo "$THIS: configured to install feature files only. Not starting test harness environment."
   exit 0
+fi
+
+echo "$THIS: LOCAL_SDK_BUILD=$LOCAL_SDK_BUILD"
+if [[ $LOCAL_SDK_BUILD == 1 ]]; then
+  stage_local_sdk_sandbox
+  echo "$THIS: seconds it took to stage $STAGED_SANDBOX: $(($(date "+%s") - START))s"
 fi
 
 ## Start test harness environment

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -259,3 +259,14 @@ type PQSig struct {
 	PublicKey []byte        `codec:"pk"`
 	Signature []byte        `codec:"sig"`
 }
+
+// Blank returns true if the PQ authorization envelope is absent.
+func (p PQSig) Blank() bool {
+	var zeroScheme PQScheme
+	var zeroSalt PQAddressSalt
+
+	return p.Scheme == zeroScheme &&
+		p.Salt == zeroSalt &&
+		len(p.PublicKey) == 0 &&
+		len(p.Signature) == 0
+}


### PR DESCRIPTION
I think this will be the wrong place for PQSig eventually, but the PR moving it to `signature.go` hasn't landed yet, so this hopefully minimizes changes`.
