### PR TITLE
fix: make API error wrappers distinguishable at runtime

### DIFF
--- a/client/v2/common/common.go
+++ b/client/v2/common/common.go
@@ -78,10 +78,55 @@ func MakeClientWithTransport(address string, apiHeader, apiToken string, headers
 	return
 }
 
-type BadRequest error
-type InvalidToken error
-type NotFound error
-type InternalError error
+// HTTPError is returned for non-2xx HTTP responses that do not map to a more specific type.
+type HTTPError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e HTTPError) Error() string {
+	return fmt.Sprintf("HTTP %v: %s", e.StatusCode, e.Message)
+}
+
+// BadRequest is returned for HTTP 400 responses.
+type BadRequest struct {
+	StatusCode int
+	Message    string
+}
+
+func (e BadRequest) Error() string {
+	return fmt.Sprintf("HTTP %v: %s", e.StatusCode, e.Message)
+}
+
+// InvalidToken is returned for HTTP 401 responses.
+type InvalidToken struct {
+	StatusCode int
+	Message    string
+}
+
+func (e InvalidToken) Error() string {
+	return fmt.Sprintf("HTTP %v: %s", e.StatusCode, e.Message)
+}
+
+// NotFound is returned for HTTP 404 responses.
+type NotFound struct {
+	StatusCode int
+	Message    string
+}
+
+func (e NotFound) Error() string {
+	return fmt.Sprintf("HTTP %v: %s", e.StatusCode, e.Message)
+}
+
+// InternalError is returned for HTTP 500 responses.
+type InternalError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e InternalError) Error() string {
+	return fmt.Sprintf("HTTP %v: %s", e.StatusCode, e.Message)
+}
 
 // extractError checks if the response signifies an error.
 // If so, it returns the error.
@@ -91,18 +136,18 @@ func extractError(code int, errorBuf []byte) error {
 		return nil
 	}
 
-	wrappedError := fmt.Errorf("HTTP %v: %s", code, errorBuf)
+	msg := string(errorBuf)
 	switch code {
 	case 400:
-		return BadRequest(wrappedError)
+		return BadRequest{StatusCode: code, Message: msg}
 	case 401:
-		return InvalidToken(wrappedError)
+		return InvalidToken{StatusCode: code, Message: msg}
 	case 404:
-		return NotFound(wrappedError)
+		return NotFound{StatusCode: code, Message: msg}
 	case 500:
-		return InternalError(wrappedError)
+		return InternalError{StatusCode: code, Message: msg}
 	default:
-		return wrappedError
+		return HTTPError{StatusCode: code, Message: msg}
 	}
 }
 

--- a/client/v2/common/common_test.go
+++ b/client/v2/common/common_test.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -18,17 +17,39 @@ func TestExtractError(t *testing.T) {
 		code int
 		err  error
 	}{
-		{name: "400", code: 400, err: BadRequest(fmt.Errorf("HTTP 400: "))},
-		{name: "401", code: 401, err: InvalidToken(fmt.Errorf("HTTP 401: "))},
-		{name: "404", code: 404, err: NotFound(fmt.Errorf("HTTP 404: "))},
-		{name: "500", code: 500, err: InternalError(fmt.Errorf("HTTP 500: "))},
+		{name: "400", code: 400, err: BadRequest{StatusCode: 400, Message: ""}},
+		{name: "401", code: 401, err: InvalidToken{StatusCode: 401, Message: ""}},
+		{name: "404", code: 404, err: NotFound{StatusCode: 404, Message: ""}},
+		{name: "500", code: 500, err: InternalError{StatusCode: 500, Message: ""}},
+		{name: "418", code: 418, err: HTTPError{StatusCode: 418, Message: ""}},
 		{name: "200", code: 200, err: nil},
 		{name: "201", code: 201, err: nil},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.err, extractError(tc.code, []byte{}))
+			err := extractError(tc.code, []byte{})
+			assert.Equal(t, tc.err, err)
+			if err != nil {
+				// Ensure concrete types are distinguishable at runtime.
+				switch tc.code {
+				case 400:
+					_, ok := err.(BadRequest)
+					assert.True(t, ok)
+				case 401:
+					_, ok := err.(InvalidToken)
+					assert.True(t, ok)
+				case 404:
+					_, ok := err.(NotFound)
+					assert.True(t, ok)
+				case 500:
+					_, ok := err.(InternalError)
+					assert.True(t, ok)
+				default:
+					_, ok := err.(HTTPError)
+					assert.True(t, ok)
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Replaces `type BadRequest error` (and siblings) with concrete structs that implement `error`.
- Each typed error includes `StatusCode` and `Message`, so `errors.As` / type assertions work at runtime.
- Adds `HTTPError` for non-mapped status codes.
- Extends unit tests to assert runtime type distinguishability.

## Context
Fixes #501. Type aliases to the `error` interface are indistinguishable at runtime; callers cannot reliably switch on API failure class.

## Validation
```bash
go test ./client/v2/common/ -count=1
```